### PR TITLE
redis TTL is in seconds instead of millis

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -69,8 +69,8 @@ public class RedisCache implements SyncCache<StatefulConnection<?, ?>> {
             throw new IllegalArgumentException("Redis cache configuration cannot be null");
         }
         this.redisCacheConfiguration = redisCacheConfiguration;
-        this.expireAfterWrite = redisCacheConfiguration.getExpireAfterWrite().map(Duration::toMillis).orElse(null);
-        this.expireAfterAccess = redisCacheConfiguration.getExpireAfterAccess().map(Duration::toMillis).orElse(null);
+        this.expireAfterWrite = redisCacheConfiguration.getExpireAfterWrite().map(Duration::getSeconds).orElse(null);
+        this.expireAfterAccess = redisCacheConfiguration.getExpireAfterAccess().map(Duration::getSeconds).orElse(null);
         this.keySerializer = redisCacheConfiguration
             .getKeySerializer()
             .flatMap(beanLocator::findOrInstantiateBean)


### PR DESCRIPTION
Using configured expirations led to unexpected huge TTL because of a wrong time unit (millis instead of seconds).

See: https://redis.io/commands/set and https://redis.io/commands/expire commands