### PR TITLE
Changed expiration commands to use PX for millis instead of EX for millis

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AsyncCacheCommands.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AsyncCacheCommands.java
@@ -66,17 +66,17 @@ public interface AsyncCacheCommands extends Commands {
      * @param timeout The timeout
      * @return result of completion
      */
-    @Command("SET :key :value EX :timeout")
+    @Command("SET :key :value PX :timeout")
     RedisFuture<Void> put(@Param("key") byte[] key, @Param("value") byte[] value, @Param("timeout") long timeout);
 
     /**
-     * See https://redis.io/commands/expire.
+     * See https://redis.io/commands/pexpire.
      *
      * @param key     The key to expire
      * @param timeout The timeout
      * @return result of completion
      */
-    @Command("EXPIRE :key :timeout")
+    @Command("PEXPIRE :key :timeout")
     RedisFuture<Void> expire(@Param("key") byte[] key, @Param("timeout") long timeout);
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/SyncCacheCommands.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/SyncCacheCommands.java
@@ -62,16 +62,16 @@ public interface SyncCacheCommands extends Commands {
      * @param value   The value
      * @param timeout The timeout
      */
-    @Command("SET :key :value EX :timeout")
+    @Command("SET :key :value PX :timeout")
     void put(@Param("key") byte[] key, @Param("value") byte[] value, @Param("timeout") long timeout);
 
     /**
-     * See https://redis.io/commands/expire.
+     * See https://redis.io/commands/pexpire.
      *
      * @param key     The key to expire
      * @param timeout The timeout
      */
-    @Command("EXPIRE :key :timeout")
+    @Command("PEXPIRE :key :timeout")
     void expire(@Param("key") byte[] key, @Param("timeout") long timeout);
 
     /**


### PR DESCRIPTION
This solution is more flexible and suits all cases. 
Changing `this.expireAfterAccess = redisCacheConfiguration.getExpireAfterAccess().map(Duration::getSeconds).orElse(null);` to retrieve seconds will fail when e.g. expiration is set to 500 milliseconds, as 500ms = 0s due to `expireAfterAccess` being `long`