### PR TITLE
Added ability to specify a default configuration for caches

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisSetting.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisSetting.java
@@ -42,6 +42,10 @@ public interface RedisSetting {
      */
     String REDIS_EMBEDDED = PREFIX + ".embedded";
     /**
+     * Default configuration for Redis caches.
+     */
+    String REDIS_CACHE = PREFIX + ".cache";
+    /**
      * Configured Redis caches.
      */
     String REDIS_CACHES = PREFIX + ".caches";

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce.cache;
+
+import io.micronaut.core.serialize.ObjectSerializer;
+import io.micronaut.runtime.ApplicationConfiguration;
+
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Allows configuration of caches stored in Redis.
+ *
+ * @author Graeme Rocher, Alex Katlein
+ * @since 1.3
+ */
+public abstract class AbstractRedisCacheConfiguration {
+
+    protected String server;
+    protected Class<ObjectSerializer> keySerializer;
+    protected Class<ObjectSerializer> valueSerializer;
+    protected Charset charset;
+    protected Duration expireAfterWrite;
+    protected Duration expireAfterAccess;
+
+    /**
+     * Constructor.
+     *
+     * @param applicationConfiguration applicationConfiguration
+     */
+    public AbstractRedisCacheConfiguration(ApplicationConfiguration applicationConfiguration) {
+        this.charset = applicationConfiguration.getDefaultCharset();
+    }
+
+    /**
+     * @return The name of the server to use.
+     * @see io.micronaut.configuration.lettuce.NamedRedisServersConfiguration
+     */
+    public Optional<String> getServer() {
+        if (server != null) {
+            return Optional.of(server);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * @return The {@link ObjectSerializer} type to use for serializing values.
+     */
+    public Optional<Class<ObjectSerializer>> getValueSerializer() {
+        return Optional.ofNullable(valueSerializer);
+    }
+
+    /**
+     * The {@link ObjectSerializer} to use for serializing keys. Defaults to {@link io.micronaut.cache.serialize.DefaultStringKeySerializer}.
+     *
+     * @return The optional {@link ObjectSerializer} class
+     */
+    public Optional<Class<ObjectSerializer>> getKeySerializer() {
+        return Optional.ofNullable(keySerializer);
+    }
+
+    /**
+     * @return The expiry to use after the value is written
+     */
+    public Optional<Duration> getExpireAfterWrite() {
+        return Optional.ofNullable(expireAfterWrite);
+    }
+
+    /**
+     * Specifies that each entry should be automatically removed from the cache once a fixed duration
+     * has elapsed after the entry's creation, the most recent replacement of its value, or its last
+     * read.
+     *
+     * @return The {@link Duration}
+     */
+    public Optional<Duration> getExpireAfterAccess() {
+        return Optional.ofNullable(expireAfterAccess);
+    }
+
+    /**
+     * @return The charset used to serialize and deserialize values
+     */
+    public Charset getCharset() {
+        return charset;
+    }
+
+    /**
+     * @param expireAfterWrite The cache expiration duration after writing into it.
+     */
+    public void setExpireAfterWrite(Duration expireAfterWrite) {
+        this.expireAfterWrite = expireAfterWrite;
+    }
+
+    /**
+     * @param expireAfterAccess The cache expiration duration after accessing it
+     */
+    public void setExpireAfterAccess(Duration expireAfterAccess) {
+        this.expireAfterAccess = expireAfterAccess;
+    }
+
+    /**
+     * @param charset The charset used to serialize and deserialize values
+     */
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/DefaultRedisCacheConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/DefaultRedisCacheConfiguration.java
@@ -16,36 +16,23 @@
 package io.micronaut.configuration.lettuce.cache;
 
 import io.micronaut.configuration.lettuce.RedisSetting;
-import io.micronaut.context.annotation.EachProperty;
-import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.runtime.ApplicationConfiguration;
 
 /**
- * Allows configuration of caches stored in Redis.
+ * Allows providing default configuration values for the actual caches.
  *
- * @author Graeme Rocher
- * @since 1.0
+ * @author Alex Katlein
+ * @since 1.3
  */
-@EachProperty(RedisSetting.REDIS_CACHES)
-public class RedisCacheConfiguration extends AbstractRedisCacheConfiguration {
-    protected final String cacheName;
-
+@ConfigurationProperties(RedisSetting.REDIS_CACHE)
+public class DefaultRedisCacheConfiguration extends AbstractRedisCacheConfiguration {
     /**
      * Constructor.
      *
-     * @param cacheName                cacheName
      * @param applicationConfiguration applicationConfiguration
      */
-    public RedisCacheConfiguration(@Parameter String cacheName, ApplicationConfiguration applicationConfiguration) {
+    public DefaultRedisCacheConfiguration(ApplicationConfiguration applicationConfiguration) {
         super(applicationConfiguration);
-
-        this.cacheName = cacheName;
-    }
-
-    /**
-     * @return The name of the cache
-     */
-    public String getCacheName() {
-        return cacheName;
     }
 }


### PR DESCRIPTION
This will allow users to specify default configuration values for all their Redis caches, e.g. a default serializer. Previously this serializer had to be specified for each cache individually which adds noise to the configuration file. This applies to all properties except charset which is inherited from the application context.

Both DefaultRedisCacheConfiguration and RedisCacheConfiguration extend AbstractRedisCacheConfiguration to get optimal overlap of configuration without duplicate code. The only difference is that RedisCacheConfiguration provides the cache name, as AbstractRedisCacheConfiguration doesn't know it.

Functionally RedisCacheConfiguration has the same interface as before so existing code will remain untouched.