### PR TITLE
InvalidateAll with empty cache

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -188,7 +188,9 @@ public class RedisCache implements SyncCache<StatefulConnection<?, ?>> {
     @Override
     public void invalidateAll() {
         List<byte[]> keys = getCommands().keys(getKeysPattern().getBytes(redisCacheConfiguration.getCharset()));
-        getCommands().del(keys.toArray(new byte[keys.size()][]));
+        if (!keys.isEmpty()) {
+            getCommands().del(keys.toArray(new byte[keys.size()][]));
+        }
     }
 
     @Override

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
@@ -84,6 +84,10 @@ class RedisCacheSpec extends Specification {
         !redisCache.get("test", Foo).isPresent()
         !redisCache.get("two", Foo).isPresent()
 
+        then:
+        // invalidate an empty cache should not fail
+        redisCache.invalidateAll()
+
         cleanup:
         applicationContext.stop()
     }


### PR DESCRIPTION
An exception is thrown when the cache is empty and invalidateAll is called. This PR addresses that issue