### PR TITLE
Fix HeathCheck issue with RedisClusterClient

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -36,6 +36,7 @@ import javax.inject.Singleton;
 @Requires(beans = DefaultRedisConfiguration.class)
 @Singleton
 @Factory
+@Requires(missingProperty = RedisSetting.REDIS_URIS)
 public class DefaultRedisClientFactory extends AbstractRedisClientFactory {
 
     @Bean(preDestroy = "shutdown")

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -66,6 +66,8 @@ public class RedisHealthIndicator implements HealthIndicator {
      *
      * @param beanContext      beanContext
      * @param healthAggregator healthAggregator
+     * @param redisConnections redisConnections
+     * @param redisClusteredConnections redisClusteredConnections
      */
     public RedisHealthIndicator(BeanContext beanContext, HealthAggregator<?> healthAggregator, StatefulRedisConnection[] redisConnections, StatefulRedisClusterConnection[] redisClusteredConnections) {
         this.beanContext = beanContext;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -16,7 +16,11 @@
 package io.micronaut.configuration.lettuce.health;
 
 import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.Requires;
@@ -32,6 +36,7 @@ import javax.inject.Singleton;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 
 /**
  * A Health Indicator for Redis.
@@ -52,32 +57,40 @@ public class RedisHealthIndicator implements HealthIndicator {
 
     private final BeanContext beanContext;
     private final HealthAggregator<?> healthAggregator;
-    private final StatefulRedisConnection[] connections;
+    // Must include the connections otherwise the health check will be unknown until the first Redis command executed
+    private final StatefulRedisConnection[] redisConnections;
+    private final StatefulRedisClusterConnection[] redisClusteredConnections;
 
     /**
      * Constructor.
      *
      * @param beanContext      beanContext
      * @param healthAggregator healthAggregator
-     * @param connections      connections
      */
-    public RedisHealthIndicator(BeanContext beanContext, HealthAggregator<?> healthAggregator, StatefulRedisConnection... connections) {
+    public RedisHealthIndicator(BeanContext beanContext, HealthAggregator<?> healthAggregator, StatefulRedisConnection[] redisConnections, StatefulRedisClusterConnection[] redisClusteredConnections) {
         this.beanContext = beanContext;
         this.healthAggregator = healthAggregator;
-        this.connections = connections;
+        this.redisConnections = redisConnections;
+        this.redisClusteredConnections = redisClusteredConnections;
     }
 
     @Override
     public Publisher<HealthResult> getResult() {
-        Collection<BeanRegistration<RedisClient>> registrations = beanContext.getActiveBeanRegistrations(RedisClient.class);
-        Flux<BeanRegistration<RedisClient>> redisClients = Flux.fromIterable(registrations);
+        Publisher<HealthResult> clientResults = getResult(RedisClient.class, RedisClient::connect, StatefulRedisConnection::reactive);
+        Publisher<HealthResult> clusteredClientResults = getResult(RedisClusterClient.class, RedisClusterClient::connect, StatefulRedisClusterConnection::reactive);
+        return Flux.merge(clientResults, clusteredClientResults);
+    }
+
+    private <T, R extends StatefulConnection<K, V>, K, V> Publisher<HealthResult> getResult(Class<T> type, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {
+        Collection<BeanRegistration<T>> registrations = beanContext.getActiveBeanRegistrations(type);
+        Flux<BeanRegistration<T>> redisClients = Flux.fromIterable(registrations);
 
         Flux<HealthResult> healthResultFlux = redisClients.flatMap(client -> {
-            StatefulRedisConnection<String, String> connection;
+            R connection;
             String connectionName = client.getIdentifier().getName();
             String dbName = "redis(" + connectionName + ")";
             try {
-                connection = client.getBean().connect();
+                connection = getConnection.apply(client.getBean());
             } catch (Exception e) {
                 HealthResult result = HealthResult
                         .builder(dbName, HealthStatus.DOWN)
@@ -86,7 +99,7 @@ public class RedisHealthIndicator implements HealthIndicator {
                 return Flux.just(result);
             }
 
-            Mono<String> pingCommand = connection.reactive().ping();
+            Mono<String> pingCommand = getReactive.apply(connection).ping();
             pingCommand = pingCommand.timeout(Duration.ofSeconds(TIMEOUT_SECONDS)).retry(RETRY);
             return pingCommand.map(s -> {
                 try {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -64,9 +64,9 @@ public class RedisHealthIndicator implements HealthIndicator {
     /**
      * Constructor.
      *
-     * @param beanContext      beanContext
-     * @param healthAggregator healthAggregator
-     * @param redisConnections redisConnections
+     * @param beanContext               beanContext
+     * @param healthAggregator          healthAggregator
+     * @param redisConnections          redisConnections
      * @param redisClusteredConnections redisClusteredConnections
      */
     public RedisHealthIndicator(BeanContext beanContext, HealthAggregator<?> healthAggregator, StatefulRedisConnection[] redisConnections, StatefulRedisClusterConnection[] redisClusteredConnections) {
@@ -80,7 +80,7 @@ public class RedisHealthIndicator implements HealthIndicator {
     public Publisher<HealthResult> getResult() {
         Publisher<HealthResult> clientResults = getResult(RedisClient.class, RedisClient::connect, StatefulRedisConnection::reactive);
         Publisher<HealthResult> clusteredClientResults = getResult(RedisClusterClient.class, RedisClusterClient::connect, StatefulRedisClusterConnection::reactive);
-        return Flux.merge(clientResults, clusteredClientResults);
+        return Flux.concat(clientResults, clusteredClientResults);
     }
 
     private <T, R extends StatefulConnection<K, V>, K, V> Publisher<HealthResult> getResult(Class<T> type, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -58,22 +58,22 @@ public class RedisHealthIndicator implements HealthIndicator {
     private final BeanContext beanContext;
     private final HealthAggregator<?> healthAggregator;
     // Must include the connections otherwise the health check will be unknown until the first Redis command executed
-    private final StatefulRedisConnection[] redisConnections;
-    private final StatefulRedisClusterConnection[] redisClusteredConnections;
+    private final RedisClient[] redisClients;
+    private final RedisClusterClient[] redisClusterClients;
 
     /**
      * Constructor.
      *
-     * @param beanContext               beanContext
-     * @param healthAggregator          healthAggregator
-     * @param redisConnections          redisConnections
-     * @param redisClusteredConnections redisClusteredConnections
+     * @param beanContext         beanContext
+     * @param healthAggregator    healthAggregator
+     * @param redisClients        redisClients
+     * @param redisClusterClients redisClusterClients
      */
-    public RedisHealthIndicator(BeanContext beanContext, HealthAggregator<?> healthAggregator, StatefulRedisConnection[] redisConnections, StatefulRedisClusterConnection[] redisClusteredConnections) {
+    public RedisHealthIndicator(BeanContext beanContext, HealthAggregator<?> healthAggregator, RedisClient[] redisClients, RedisClusterClient[] redisClusterClients) {
         this.beanContext = beanContext;
         this.healthAggregator = healthAggregator;
-        this.redisConnections = redisConnections;
-        this.redisClusteredConnections = redisClusteredConnections;
+        this.redisClients = redisClients;
+        this.redisClusterClients = redisClusterClients;
     }
 
     @Override

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/session/RedisSessionStore.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/session/RedisSessionStore.java
@@ -494,7 +494,6 @@ public class RedisSessionStore extends RedisPubSubAdapter<String, String> implem
             this.modifications.add(Modification.CREATED);
         }
 
-
         /**
          * Construct a new Redis session from existing redis data.
          *


### PR DESCRIPTION
Fixes the following issues:
- Health Check now checks both clustered and non-clustered clients
- When using clustered mode, a standalone client is no longer instantiated causing the health check to fail

Open to suggestions on how to improve the code:
- I want to reuse the code, but limited because RedisClient and RedisClusterClient are in an external pacakage
- Tried creating a test, but the clustered embedded redis supports sentinal connections and we are not using that