### PR TITLE
Fix GraalVM for Micronaut 2.4

### DIFF
--- a/redis-lettuce/src/main/resources/META-INF/native-image/io.micronaut.redis/redis-lettuce/native-image.properties
+++ b/redis-lettuce/src/main/resources/META-INF/native-image/io.micronaut.redis/redis-lettuce/native-image.properties
@@ -1,2 +1,2 @@
 Args = --initialize-at-build-time=io.lettuce.core.metrics.DefaultCommandLatencyCollector,io.lettuce.core.internal.LettuceClassUtils \
-       --initialize-at-run-time=reactor.core.publisher.Mono,reactor.core.publisher.Flux,io.micronaut.core.async.publisher.Publishers,io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfigurationDefinition
+       --initialize-at-run-time=reactor.core.publisher.Mono,reactor.core.publisher.Flux,io.micronaut.core.async.publisher.Publishers,io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfigurationDefinition,io.micronaut.aop.internal.intercepted.PublisherInterceptedMethod


### PR DESCRIPTION
This PR fixes the Micronaut Redis GraalVM integration for Micronaut 2.4. It is backwards compatible with 2.3.

This is the error: https://gitlab.com/micronaut-projects/micronaut-graal-tests/-/jobs/1052434319#L68

```
> Task :nativeImage
[redis:198]    classlist:   4,967.49 ms,  1.91 GB
[redis:198]        (cap):     512.94 ms,  1.91 GB
[redis:198]        setup:   2,241.97 ms,  1.91 GB
To see how the classes got initialized, use --trace-class-initialization=reactor.core.publisher.Mono,io.micronaut.core.async.publisher.Publishers,reactor.core.publisher.Flux
[redis:198]     analysis:  46,868.54 ms,  3.14 GB
Error: Classes that should be initialized at run time got initialized during image building:
 reactor.core.publisher.Mono the class was requested to be initialized at run time (from the command line). To see why reactor.core.publisher.Mono got initialized use --trace-class-initialization=reactor.core.publisher.Mono
io.micronaut.core.async.publisher.Publishers the class was requested to be initialized at run time (from the command line). To see why io.micronaut.core.async.publisher.Publishers got initialized use --trace-class-initialization=io.micronaut.core.async.publisher.Publishers
reactor.core.publisher.Flux the class was requested to be initialized at run time (from the command line). To see why reactor.core.publisher.Flux got initialized use --trace-class-initialization=reactor.core.publisher.Flux
Error: Use -H:+ReportExceptionStackTraces to print stacktrace of underlying exception
Error: Image build request failed with exit status 1
FAILURE: Build failed with an exception.
```