### PR TITLE
Support lettuce latency metrics

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ micronautBuildVersion=1.1.5
 groovyVersion=3.0.5
 spockVersion=2.0-M3-groovy-3.0
 
-lettuceVersion=6.1.0.M1
+lettuceVersion=6.1.0.RELEASE
 micrometerVersion=1.5.1
 validationVersion=2.0.1.Final
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ micronautBuildVersion=1.1.5
 groovyVersion=3.0.5
 spockVersion=2.0-M3-groovy-3.0
 
-lettuceVersion=6.0.3.RELEASE
+lettuceVersion=6.1.0.M1
 micrometerVersion=1.5.1
 validationVersion=2.0.1.Final
 

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -9,12 +9,14 @@ dependencies {
 
     compileOnly "io.micronaut:micronaut-session"
     compileOnly "io.micronaut:micronaut-management"
+    compileOnly "io.micronaut.micrometer:micronaut-micrometer-core"
     compileOnly "com.github.kstyrc:embedded-redis:0.6"
 
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"
     testImplementation "io.micronaut.cache:micronaut-cache-core"
     testImplementation "io.micronaut:micronaut-inject-java"
     testImplementation "io.micronaut:micronaut-management"
+    testImplementation "io.micronaut.micrometer:micronaut-micrometer-core"
     testImplementation "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut:micronaut-function-web"
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
@@ -22,6 +22,7 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
 
 import io.micronaut.core.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,6 +63,19 @@ public abstract class AbstractRedisClientFactory {
         Optional<RedisURI> uri = config.getUri();
         return uri.map(redisURI -> RedisClient.create(clientResources, redisURI))
             .orElseGet(() -> RedisClient.create(clientResources, config));
+    }
+
+    /**
+     * Creates the {@link RedisClient} from the configuration.
+     *
+     * @param config The configuration
+     * @param optionalClientResources The ClientResources
+     * @deprecated use {@link #redisClient(AbstractRedisConfiguration, ClientResources, List)} instead
+     * @return The {@link RedisClient}
+     */
+    @Deprecated
+    public RedisClient redisClient(AbstractRedisConfiguration config, @Nullable ClientResources optionalClientResources) {
+        return this.redisClient(config, optionalClientResources, Collections.emptyList());
     }
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -84,7 +84,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * Returns the pool size (number of threads) for IO threads. The indicated size does not reflect the number for all IO
      * threads. TCP and socket connections (epoll) require different IO pool.
      *
-     * {@link ClientResources#ioThreadPoolSize()}
+     * {@link io.lettuce.core.resource.ClientResources#ioThreadPoolSize()}
      *
      * @return the pool size (number of threads) for all IO tasks.
      */
@@ -94,9 +94,9 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
 
     /**
      * Sets the thread pool size (number of threads to use) for I/O operations (default value is the number of CPUs). The
-     * thread pool size is only effective if no {@link ClientResources.Builder#eventLoopGroupProvider} is provided.
+     * thread pool size is only effective if no {@link io.lettuce.core.resource.ClientResources.Builder#eventLoopGroupProvider} is provided.
      *
-     * {@link ClientResources.Builder#ioThreadPoolSize(int)}
+     * {@link io.lettuce.core.resource.ClientResources.Builder#ioThreadPoolSize(int)}
      *
      * @param ioThreadPoolSize the thread pool size, must be greater {@code 0}.
      */
@@ -107,7 +107,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     /**
      * Returns the pool size (number of threads) for all computation tasks.
      *
-     * {@link ClientResources#computationThreadPoolSize()}
+     * {@link io.lettuce.core.resource.ClientResources#computationThreadPoolSize()}
      *
      * @return the pool size (number of threads to use).
      */
@@ -117,9 +117,9 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
 
     /**
      * Sets the thread pool size (number of threads to use) for computation operations (default value is the number of
-     * CPUs). The thread pool size is only effective if no {@link ClientResources.Builder#eventExecutorGroup} is provided.
+     * CPUs). The thread pool size is only effective if no {@link io.lettuce.core.resource.ClientResources.Builder#eventExecutorGroup} is provided.
      *
-     * {@link ClientResources.Builder#computationThreadPoolSize(int)}
+     * {@link io.lettuce.core.resource.ClientResources.Builder#computationThreadPoolSize(int)}
      *
      * @param computationThreadPoolSize the thread pool size, must be greater {@code 0}.
      */

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ClientResourcesMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ClientResourcesMutator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce;
+
+import io.lettuce.core.resource.ClientResources;
+
+/**
+ * Mutates a {@link ClientResources.Builder}.
+ * @author Rafael Acevedo
+ */
+public interface ClientResourcesMutator {
+    void mutate(ClientResources.Builder builder, AbstractRedisConfiguration config);
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ClientResourcesMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ClientResourcesMutator.java
@@ -20,6 +20,7 @@ import io.lettuce.core.resource.ClientResources;
 /**
  * Mutates a {@link ClientResources.Builder}.
  * @author Rafael Acevedo
+ * @since 4.1
  */
 public interface ClientResourcesMutator {
     void mutate(ClientResources.Builder builder, AbstractRedisConfiguration config);

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ClientResourcesMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ClientResourcesMutator.java
@@ -16,12 +16,20 @@
 package io.micronaut.configuration.lettuce;
 
 import io.lettuce.core.resource.ClientResources;
+import io.micronaut.core.annotation.Indexed;
 
 /**
  * Mutates a {@link ClientResources.Builder}.
  * @author Rafael Acevedo
  * @since 4.1
  */
+@Indexed(ClientResourcesMutator.class)
 public interface ClientResourcesMutator {
+
+    /**
+     * Mutates a {@link ClientResources.Builder}.
+     * @param builder the builder
+     * @param config the redis config
+     */
     void mutate(ClientResources.Builder builder, AbstractRedisConfiguration config);
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -26,6 +26,7 @@ import io.micronaut.context.annotation.Requires;
 
 import io.micronaut.core.annotation.Nullable;
 import javax.inject.Singleton;
+import java.util.List;
 
 /**
  * Factory for the default {@link RedisClient}. Creates the injectable {@link Primary} bean.
@@ -43,8 +44,8 @@ public class DefaultRedisClientFactory extends AbstractRedisClientFactory {
     @Singleton
     @Primary
     @Override
-    public RedisClient redisClient(@Primary AbstractRedisConfiguration config, @Nullable @Primary ClientResources defaultClientResources) {
-        return super.redisClient(config, defaultClientResources);
+    public RedisClient redisClient(@Primary AbstractRedisConfiguration config, @Nullable @Primary ClientResources defaultClientResources, @Nullable List<ClientResourcesMutator> mutators) {
+        return super.redisClient(config, defaultClientResources, mutators);
     }
 
     @Override

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/MetricsClientResourceMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/MetricsClientResourceMutator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce;
+
+import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
+import io.lettuce.core.metrics.MicrometerOptions;
+import io.lettuce.core.resource.ClientResources;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micronaut.context.annotation.Requires;
+
+import javax.inject.Singleton;
+
+/**
+ * Mutates a {@link ClientResources.Builder} adding {@link MicrometerCommandLatencyRecorder}.
+ * @author Rafael Acevedo
+ */
+@Singleton
+@Requires(beans = MeterRegistry.class)
+public class MetricsClientResourceMutator implements ClientResourcesMutator {
+    private final MeterRegistry meterRegistry;
+
+    public MetricsClientResourceMutator(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public void mutate(ClientResources.Builder builder, AbstractRedisConfiguration config) {
+        MicrometerOptions options = MicrometerOptions.builder().histogram(true).build();
+        builder.commandLatencyRecorder(new MicrometerCommandLatencyRecorder(meterRegistry, options));
+    }
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/MetricsClientResourceMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/MetricsClientResourceMutator.java
@@ -26,6 +26,7 @@ import javax.inject.Singleton;
 /**
  * Mutates a {@link ClientResources.Builder} adding {@link MicrometerCommandLatencyRecorder}.
  * @author Rafael Acevedo
+ * @since 4.1
  */
 @Singleton
 @Requires(beans = MeterRegistry.class)

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
@@ -28,6 +28,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 
+import java.util.List;
 
 /**
  * A factory bean for constructing {@link RedisClient} instances from {@link NamedRedisServersConfiguration} instances.
@@ -54,12 +55,13 @@ public class NamedRedisClientFactory extends AbstractRedisClientFactory {
      * Creates the {@link RedisClient} from the configuration.
      *
      * @param config The configuration
+     * @param mutators the list of mutators
      * @return The {@link RedisClient}
      */
     @Bean(preDestroy = "shutdown")
     @EachBean(NamedRedisServersConfiguration.class)
-    public RedisClient redisClient(NamedRedisServersConfiguration config) {
-        return super.redisClient(config, getClientResources(config));
+    public RedisClient redisClient(NamedRedisServersConfiguration config, @Nullable List<ClientResourcesMutator> mutators) {
+        return super.redisClient(config, getClientResources(config), mutators);
     }
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ThreadPoolClientResourceMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ThreadPoolClientResourceMutator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce;
+
+import io.lettuce.core.resource.ClientResources;
+
+import javax.inject.Singleton;
+
+/**
+ * Mutates a {@link ClientResources.Builder} adding lettuce threadpool configs.
+ * @author Rafael Acevedo
+ */
+@Singleton
+public class ThreadPoolClientResourceMutator implements ClientResourcesMutator {
+
+    @Override
+    public void mutate(ClientResources.Builder builder, AbstractRedisConfiguration config) {
+        if (config.getIoThreadPoolSize() != null) {
+            builder.ioThreadPoolSize(config.getIoThreadPoolSize());
+        }
+        if (config.getComputationThreadPoolSize() != null) {
+            builder.computationThreadPoolSize(config.getComputationThreadPoolSize());
+        }
+    }
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ThreadPoolClientResourceMutator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/ThreadPoolClientResourceMutator.java
@@ -22,6 +22,7 @@ import javax.inject.Singleton;
 /**
  * Mutates a {@link ClientResources.Builder} adding lettuce threadpool configs.
  * @author Rafael Acevedo
+ * @since 4.1
  */
 @Singleton
 public class ThreadPoolClientResourceMutator implements ClientResourcesMutator {


### PR DESCRIPTION
Closes #121 

This adds support for lettuce command latency metrics, using lettuce's newly added support for micrometer (added in lettuce 6.1.0.M1).

Note: we should probably wait for lettuce's official 6.1 release to merge this.