### PR TITLE
Add Property to disable RedisHealthIndicator

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.health.HealthStatus;
 import io.micronaut.management.health.aggregator.HealthAggregator;
 import io.micronaut.management.health.indicator.HealthIndicator;
@@ -41,6 +42,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Function;
 
+import static io.micronaut.configuration.lettuce.health.RedisHealthIndicator.NAME;
+
 /**
  * A Health Indicator for Redis.
  *
@@ -49,6 +52,7 @@ import java.util.function.Function;
  */
 @Singleton
 @Requires(classes = HealthIndicator.class)
+@Requires(property = NAME + ".health.enabled", defaultValue = StringUtils.TRUE, notEquals = StringUtils.FALSE)
 public class RedisHealthIndicator implements HealthIndicator {
     public static final Logger LOG = LoggerFactory.getLogger(RedisHealthIndicator.class);
     /**

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorSpec.groovy
@@ -64,4 +64,28 @@ class RedisHealthIndicatorSpec extends Specification {
         cleanup:
         applicationContext.close()
     }
+
+    void "redis health indicator is not loaded when disabled"() {
+        given:
+        def port = SocketUtils.findAvailableTcpPort()
+        RedisServer redisServer = RedisServer.builder().port(port).setting(MAX_HEAP_SETTING).build()
+        redisServer.start()
+
+        when:
+        ApplicationContext applicationContext = ApplicationContext.run(['redis.port': port, 'redis.health.enabled': 'false'])
+        RedisClient client = applicationContext.getBean(RedisClient)
+
+        then:
+        client != null
+
+        when:
+        Optional<RedisHealthIndicator> healthIndicator = applicationContext.findBean(RedisHealthIndicator)
+
+        then:
+        healthIndicator.empty
+
+        cleanup:
+        redisServer?.stop()
+        applicationContext.close()
+    }
 }


### PR DESCRIPTION
- Add property to disable the redis bean
- Add integration test that ensures the bean is not loaded when disabled

--

I have a use-case in a project where redis health is not something I need to care about in my `health` endpoint.
Currently I'm replacing the `RedisHealthIndicator` with a custom implementation that always returns `UP`, but offering a way to disable it as part of the library seems like a cleaner, better option.