### PR TITLE
fix: restricting embedded Redis server to only listen on localhost

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRedisConfiguration>, Closeable {
 
     private static final String DEFAULT_MAXMEMORY_SETTING = "maxmemory 256M";
-    private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1";
+    private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1 ::1";
 
     private final Configuration embeddedConfiguration;
     private RedisServer redisServer;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRedisConfiguration>, Closeable {
 
     private static final String DEFAULT_MAXMEMORY_SETTING = "maxmemory 256M";
+    private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1";
+
     private final Configuration embeddedConfiguration;
     private RedisServer redisServer;
 
@@ -74,6 +76,7 @@ public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRed
             RedisServerBuilder builder = embeddedConfiguration.builder;
             builder.port(port);
             builder.setting(DEFAULT_MAXMEMORY_SETTING);
+            builder.setting(DEFAULT_BIND_SETTING);
             redisServer = builder.build();
             redisServer.start();
 


### PR DESCRIPTION
## what

- Embedded Redis server listening restricted to receiving local traffic

```
lsof -iTCP:6379                                           
COMMAND     PID    USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
redis-ser 70180 gausnes    4u  IPv4 0x88e33edf4d247f65      0t0  TCP localhost:6379 (LISTEN)
redis-ser 70180 gausnes    5u  IPv6 0x88e33edf4564748d      0t0  TCP localhost:6379 (LISTEN)
redis-ser 70180 gausnes    6u  IPv4 0x88e33edf5c4b853d      0t0  TCP localhost:6379->localhost:60085 (ESTABLISHED)
java      70243 gausnes  178u  IPv6 0x88e33edf3fabe48d      0t0  TCP localhost:60085->localhost:6379 (ESTABLISHED)
```

## why

- A team member was worried they got hacked after Redis server was correctly cleanup up after a test run
- The embedded Redis does not need to be externally accessible

```
> lsof -iTCP:6379

COMMAND     PID    USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
java      51351 gausnes  180u  IPv6 0x88e33edf4cd69e0d      0t0  TCP localhost:50503->localhost:6379 (ESTABLISHED)
redis-ser 51354 gausnes    4u  IPv6 0x88e33edf4cd6914d      0t0  TCP *:6379 (LISTEN)
redis-ser 51354 gausnes    5u  IPv4 0x88e33edf634b96c5      0t0  TCP *:6379 (LISTEN)
redis-ser 51354 gausnes    6u  IPv4 0x88e33edf5c564f65      0t0  TCP localhost:6379->localhost:50503 (ESTABLISHED)
```

