### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/redis-lettuce/src/main/resources/META-INF/native-image/io.micronaut.redis/redis-lettuce/native-image.properties
+++ b/redis-lettuce/src/main/resources/META-INF/native-image/io.micronaut.redis/redis-lettuce/native-image.properties
@@ -1,1 +1,17 @@
-Args = --initialize-at-run-time=reactor.core.publisher.Mono,reactor.core.publisher.Flux,io.micronaut.core.async.publisher.Publishers,io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfigurationDefinition,io.micronaut.aop.internal.intercepted.PublisherInterceptedMethod
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=reactor.core.publisher.Mono,reactor.core.publisher.Flux,io.micronaut.core.async.publisher.Publishers,io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfigurationDefinition,io.micronaut.aop.internal.intercepted.PublisherInterceptedMethod,io.micronaut.cache.jcache.$JCacheManager$Definition,io.micronaut.cache.jcache.metrics.$JCacheMetricsBinder$Definition,io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfiguration$Definition,io.micronaut.configuration.lettuce.session.$RedisSessionStore$Definition,io.micronaut.configuration.lettuce.$MetricsClientResourceMutator$Definition,io.micronaut.configuration.lettuce.health.$RedisHealthIndicator$Definition


### PR DESCRIPTION
This PR fixes the following GraalVM warnings:

```
Warning: class initialization of class io.micronaut.configuration.lettuce.session.$RedisSessionStore$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/session/SessionStore. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.lettuce.session.$RedisSessionStore$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfiguration$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/session/SessionConfiguration. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.lettuce.session.$RedisHttpSessionConfiguration$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.lettuce.health.$RedisHealthIndicator$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/management/health/indicator/HealthIndicator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.lettuce.health.$RedisHealthIndicator$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.cache.jcache.$JCacheManager$Definition failed with exception java.lang.NoClassDefFoundError: javax/cache/Cache. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.cache.jcache.$JCacheManager$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.cache.jcache.metrics.$JCacheMetricsBinder$Definition failed with exception java.lang.NoClassDefFoundError: javax/cache/CacheManager. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.cache.jcache.metrics.$JCacheMetricsBinder$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.lettuce.$MetricsClientResourceMutator$Definition failed with exception java.lang.NoClassDefFoundError: io/micrometer/core/instrument/MeterRegistry. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.lettuce.$MetricsClientResourceMutator$Definition to explicitly request delayed initialization of this class.
```