### PR TITLE
Use version catalogs for dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,11 @@
 projectVersion=5.1.1-SNAPSHOT
 projectGroup=io.micronaut.redis
 
-micronautDocsVersion=2.0.0
 micronautVersion=3.1.3
 micronautTestVersion=3.0.3
 
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0
-testContainersVersion=1.16.3
-
-micronautCacheVersion=3.2.0
-micronautMicrometerVersion=4.1.1
-lettuceVersion=6.1.6.RELEASE
 
 title=Micronaut Redis
 projectDesc=Integration between Micronaut and Redis

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 managed-lettuce = "6.1.6.RELEASE"
 
-micronaut-cache = "3.2.0"
 micronaut-docs = "2.0.0"
 micronaut-micrometer = "4.1.1"
 
@@ -13,7 +12,7 @@ testcontainers = "1.16.3"
 managed-lettuce = { module = "io.lettuce:lettuce-core", version.ref = "managed-lettuce" }
 
 micronaut-asciidoc-props = { module = 'io.micronaut.docs:micronaut-docs-asciidoc-config-props', version.ref = 'micronaut-docs' }
-micronaut-cache = { module = 'io.micronaut.cache:micronaut-cache-core', version.ref = 'micronaut-cache' }
+micronaut-cache = { module = 'io.micronaut.cache:micronaut-cache-core'}
 micronaut-function-web = { module = 'io.micronaut:micronaut-function-web' }
 micronaut-graal = { module = 'io.micronaut:micronaut-graal' }
 micronaut-http-client = { module = 'io.micronaut:micronaut-http-client' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,33 @@
+[versions]
+managed-lettuce = "6.1.6.RELEASE"
+
+micronaut-cache = "3.2.0"
+micronaut-docs = "2.0.0"
+micronaut-micrometer = "4.1.1"
+
+redis-embedded = "0.6"
+
+testcontainers = "1.16.3"
+
+[libraries]
+managed-lettuce = { module = "io.lettuce:lettuce-core", version.ref = "managed-lettuce" }
+
+micronaut-asciidoc-props = { module = 'io.micronaut.docs:micronaut-docs-asciidoc-config-props', version.ref = 'micronaut-docs' }
+micronaut-cache = { module = 'io.micronaut.cache:micronaut-cache-core', version.ref = 'micronaut-cache' }
+micronaut-function-web = { module = 'io.micronaut:micronaut-function-web' }
+micronaut-graal = { module = 'io.micronaut:micronaut-graal' }
+micronaut-http-client = { module = 'io.micronaut:micronaut-http-client' }
+micronaut-http-server-netty = { module = 'io.micronaut:micronaut-http-server-netty' }
+micronaut-inject-groovy = { module = 'io.micronaut:micronaut-inject-groovy' }
+micronaut-inject-java = { module = 'io.micronaut:micronaut-inject-java' }
+micronaut-management = { module = 'io.micronaut:micronaut-management' }
+micronaut-micrometer = { module = 'io.micronaut.micrometer:micronaut-micrometer-core', version.ref = 'micronaut-micrometer' }
+micronaut-session = { module = 'io.micronaut:micronaut-session' }
+
+projectreactor = { module = 'io.projectreactor:reactor-core' }
+
+redis-embedded = { module = "com.github.kstyrc:embedded-redis", version.ref = "redis-embedded" }
+
+testcontainers = { module = "org.testcontainers:testcontainers" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers-spock = { module = "org.testcontainers:spock" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,5 @@ projectreactor = { module = 'io.projectreactor:reactor-core' }
 
 redis-embedded = { module = "com.github.kstyrc:embedded-redis", version.ref = "redis-embedded" }
 
-testcontainers = { module = "org.testcontainers:testcontainers" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
 testcontainers-spock = { module = "org.testcontainers:spock" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 managed-lettuce = "6.1.6.RELEASE"
 
 micronaut-docs = "2.0.0"
-micronaut-micrometer = "4.1.1"
 
 redis-embedded = "0.6"
 
@@ -20,7 +19,7 @@ micronaut-http-server-netty = { module = 'io.micronaut:micronaut-http-server-net
 micronaut-inject-groovy = { module = 'io.micronaut:micronaut-inject-groovy' }
 micronaut-inject-java = { module = 'io.micronaut:micronaut-inject-java' }
 micronaut-management = { module = 'io.micronaut:micronaut-management' }
-micronaut-micrometer = { module = 'io.micronaut.micrometer:micronaut-micrometer-core', version.ref = 'micronaut-micrometer' }
+micronaut-micrometer = { module = 'io.micronaut.micrometer:micronaut-micrometer-core'}
 micronaut-session = { module = 'io.micronaut:micronaut-session' }
 
 projectreactor = { module = 'io.projectreactor:reactor-core' }

--- a/redis-bom/build.gradle
+++ b/redis-bom/build.gradle
@@ -1,8 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.bom"
 }
-dependencies {
-    constraints {
-        api("io.lettuce:lettuce-core:$lettuceVersion")
-    }
-}

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -3,35 +3,34 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor "io.micronaut:micronaut-inject-java"
-    annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
-    annotationProcessor "io.micronaut:micronaut-graal"
+    annotationProcessor libs.micronaut.inject.java
+    annotationProcessor libs.micronaut.asciidoc.props
+    annotationProcessor libs.micronaut.graal
 
-    api "io.lettuce:lettuce-core:$lettuceVersion"
-    api "io.micronaut.cache:micronaut-cache-core:$micronautCacheVersion"
+    api libs.managed.lettuce
+    api libs.micronaut.cache
 
-    compileOnly "io.micronaut:micronaut-session"
-    compileOnly "io.micronaut:micronaut-management"
-    compileOnly "io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion"
-    compileOnly "com.github.kstyrc:embedded-redis:0.6"
+    compileOnly libs.micronaut.session
+    compileOnly libs.micronaut.management
+    compileOnly libs.micronaut.micrometer
+    compileOnly libs.redis.embedded
 
-    testAnnotationProcessor "io.micronaut:micronaut-inject-java"
+    testAnnotationProcessor libs.micronaut.inject.java
 
-    testImplementation platform("org.testcontainers:testcontainers-bom:$testContainersVersion")
-    testImplementation "org.testcontainers:testcontainers"
-    testImplementation "org.testcontainers:spock"
+    testImplementation platform(libs.testcontainers.bom)
+    testImplementation libs.testcontainers
+    testImplementation libs.testcontainers.spock
 
-    testImplementation "io.projectreactor:reactor-core"
+    testImplementation libs.projectreactor
 
-    testImplementation "io.micronaut.cache:micronaut-cache-core:$micronautCacheVersion"
-    testImplementation "io.micronaut:micronaut-inject-java"
-    testImplementation "io.micronaut:micronaut-management"
-    testImplementation "io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion"
-    testImplementation "io.micronaut:micronaut-inject-groovy"
-    testImplementation "io.micronaut:micronaut-function-web"
+    testImplementation libs.micronaut.inject.java
+    testImplementation libs.micronaut.management
+    testImplementation libs.micronaut.micrometer
+    testImplementation libs.micronaut.inject.groovy
+    testImplementation libs.micronaut.function.web
 
-    testImplementation "io.micronaut:micronaut-session"
-    testRuntimeOnly "io.micronaut:micronaut-http-server-netty"
-    testImplementation "io.micronaut:micronaut-http-client"
-    testImplementation "com.github.kstyrc:embedded-redis:0.6"
+    testImplementation libs.micronaut.session
+    testRuntimeOnly libs.micronaut.http.server.netty
+    testImplementation libs.micronaut.http.client
+    testImplementation libs.redis.embedded
 }

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     testAnnotationProcessor libs.micronaut.inject.java
 
     testImplementation platform(libs.testcontainers.bom)
-    testImplementation libs.testcontainers
     testImplementation libs.testcontainers.spock
 
     testImplementation libs.projectreactor


### PR DESCRIPTION
This switches over to using version catalogues for the dependencies

It should be a no-op so doesn't need releasing again 😉 (@sdelamo)