### PR TITLE
Next minor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ testContainersVersion=1.16.3
 
 micronautCacheVersion=3.2.0
 micronautMicrometerVersion=4.1.1
+embeddedRedisVersion=0.6
 lettuceVersion=6.1.6.RELEASE
 
 title=Micronaut Redis

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ projectVersion=5.1.1-SNAPSHOT
 projectGroup=io.micronaut.redis
 
 micronautDocsVersion=2.0.0
-micronautTestVersion=3.0.3
 micronautVersion=3.3.4
+micronautTestVersion=3.0.5
 
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.1.1-SNAPSHOT
+projectVersion=5.2.0-SNAPSHOT
 projectGroup=io.micronaut.redis
 
 micronautDocsVersion=2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ micronautDocsVersion=2.0.0
 micronautVersion=3.3.4
 micronautTestVersion=3.0.5
 
-groovyVersion=3.0.9
+groovyVersion=3.0.10
 spockVersion=2.0-groovy-3.0
 
 embeddedRedisVersion=0.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0
 testContainersVersion=1.16.3
 
-micronautCacheVersion=3.2.0
 micronautMicrometerVersion=4.1.1
 embeddedRedisVersion=0.6
 lettuceVersion=6.1.6.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0
 testContainersVersion=1.16.3
 
-micronautMicrometerVersion=4.1.1
 embeddedRedisVersion=0.6
 lettuceVersion=6.1.6.RELEASE
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ projectVersion=5.1.1-SNAPSHOT
 projectGroup=io.micronaut.redis
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.1.3
 micronautTestVersion=3.0.3
+micronautVersion=3.3.4
 
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ micronautTestVersion=3.0.3
 
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0
-testContainersVersion=1.16.3
 
 embeddedRedisVersion=0.6
 lettuceVersion=6.1.6.RELEASE

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"
 
-    testImplementation platform("org.testcontainers:testcontainers-bom:$testContainersVersion")
+    testImplementation platform("org.testcontainers:testcontainers-bom")
     testImplementation "org.testcontainers:testcontainers"
     testImplementation "org.testcontainers:spock"
 

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -33,5 +33,5 @@ dependencies {
     testImplementation "io.micronaut:micronaut-session"
     testRuntimeOnly "io.micronaut:micronaut-http-server-netty"
     testImplementation "io.micronaut:micronaut-http-client"
-    testImplementation "com.github.kstyrc:embedded-redis:0.6"
+    testImplementation "com.github.kstyrc:embedded-redis:$embeddedRedisVersion"
 }

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     annotationProcessor "io.micronaut:micronaut-graal"
 
     api "io.lettuce:lettuce-core:$lettuceVersion"
-    api "io.micronaut.cache:micronaut-cache-core:$micronautCacheVersion"
+    api "io.micronaut.cache:micronaut-cache-core"
 
     compileOnly "io.micronaut:micronaut-session"
     compileOnly "io.micronaut:micronaut-management"
@@ -23,7 +23,7 @@ dependencies {
 
     testImplementation "io.projectreactor:reactor-core"
 
-    testImplementation "io.micronaut.cache:micronaut-cache-core:$micronautCacheVersion"
+    testImplementation "io.micronaut.cache:micronaut-cache-core"
     testImplementation "io.micronaut:micronaut-inject-java"
     testImplementation "io.micronaut:micronaut-management"
     testImplementation "io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion"

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
     annotationProcessor "io.micronaut:micronaut-graal"
 

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     compileOnly "io.micronaut:micronaut-session"
     compileOnly "io.micronaut:micronaut-management"
-    compileOnly "io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion"
+    compileOnly "io.micronaut.micrometer:micronaut-micrometer-core"
     compileOnly "com.github.kstyrc:embedded-redis:0.6"
 
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"
@@ -26,7 +26,7 @@ dependencies {
     testImplementation "io.micronaut.cache:micronaut-cache-core"
     testImplementation "io.micronaut:micronaut-inject-java"
     testImplementation "io.micronaut:micronaut-management"
-    testImplementation "io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion"
+    testImplementation "io.micronaut.micrometer:micronaut-micrometer-core"
     testImplementation "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut:micronaut-function-web"
 

--- a/redis-lettuce/build.gradle
+++ b/redis-lettuce/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
     annotationProcessor "io.micronaut:micronaut-graal"
 
     api "io.lettuce:lettuce-core:$lettuceVersion"


### PR DESCRIPTION
- move embedded redis version to `gradle.properties`
- remove `micronautCacheVersion`
- remove `micronautMicrometerVersion`
- remove `testContainers` version. 
- remove `micronaut-inject-java` ann processor
- remove `micronaut-asciidoc-config-props`
- update to micronaut 3.3.4
- update to micronaut test to 3.0.5
- update groovy version to 3.0.10
- set project version to 5.2.0-SNAPSHOT