### PR TITLE
Address feedback for connection pool

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConnectionPoolConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConnectionPoolConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.configuration.lettuce;
 
+import io.micronaut.core.annotation.NonNull;
+
 import java.util.Optional;
 
 /**
@@ -34,47 +36,31 @@ public abstract class AbstractRedisConnectionPoolConfiguration {
      * @return The minimum idle connections count.
      * @see io.micronaut.configuration.lettuce.NamedRedisServersConfiguration
      */
-    public Optional<Integer> getMinIdle() {
-        if (minIdle != null) {
-            return Optional.of(minIdle);
-        } else {
-            return Optional.empty();
-        }
+    public @NonNull Optional<Integer> getMinIdle() {
+        return Optional.ofNullable(minIdle);
     }
 
     /**
      * @return The maximum idle connections count.
      * @see io.micronaut.configuration.lettuce.NamedRedisServersConfiguration
      */
-    public Optional<Integer> getMaxIdle() {
-        if (maxIdle != null) {
-            return Optional.of(maxIdle);
-        } else {
-            return Optional.empty();
-        }
+    public @NonNull Optional<Integer> getMaxIdle() {
+        return Optional.ofNullable(maxIdle);
     }
 
     /**
      * @return The maximum total connections count.
      * @see io.micronaut.configuration.lettuce.NamedRedisServersConfiguration
      */
-    public Optional<Integer> getMaxTotal() {
-        if (maxTotal != null) {
-            return Optional.of(maxTotal);
-        } else {
-            return Optional.empty();
-        }
+    public @NonNull Optional<Integer> getMaxTotal() {
+        return Optional.ofNullable(maxTotal);
     }
 
     /**
      * @return The maximum total connections count.
      * @see io.micronaut.configuration.lettuce.NamedRedisServersConfiguration
      */
-    public Optional<Boolean> getEnabled() {
-        if (enabled != null) {
-            return Optional.of(enabled);
-        } else {
-            return Optional.empty();
-        }
+    public @NonNull Optional<Boolean> getEnabled() {
+        return Optional.ofNullable(enabled);
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisConnectionPoolConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisConnectionPoolConfiguration.java
@@ -27,7 +27,7 @@ import io.micronaut.runtime.ApplicationConfiguration;
  * Allows configuration of redis connection pool.
  *
  * @author Graeme Rocher, Illia Kovalov
- * @since 1.3
+ * @since 5.3.0
  */
 @ConfigurationProperties(RedisSetting.REDIS_POOL)
 @Requires(classes = SyncCache.class, property = RedisSetting.REDIS_POOL + ".enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.FALSE)

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
@@ -25,6 +25,7 @@ import io.lettuce.core.codec.ByteArrayCodec;
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.util.Optional;
@@ -46,7 +47,7 @@ public class RedisConnectionUtil {
      * @return The connection
      * @throws ConfigurationException If the connection cannot be found
      */
-    public static AbstractRedisClient findClient(BeanLocator beanLocator, Optional<String> serverName, String errorMessage) {
+    public static @NonNull AbstractRedisClient findClient(BeanLocator beanLocator, Optional<String> serverName, String errorMessage) {
         Optional<? extends AbstractRedisClient> clusterConn = findRedisClusterClient(beanLocator, serverName);
         if (clusterConn.isPresent()) {
             return clusterConn.get();

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
@@ -39,9 +39,10 @@ import java.util.function.Supplier;
 
 /**
  * An abstract class implementing SyncCache for the redis.
- * Author: Graeme Rocher, Kovalov Illia
  *
+ * @author Graeme Rocher, Kovalov Illia
  * @param <C> – The native cache implementation
+ * @since 5.3.0
  */
 public abstract class AbstractRedisCache<C> implements SyncCache<C>, AutoCloseable {
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
@@ -37,28 +37,21 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * Default redis connection pool factory.
- * Author: Kovalov Illia
+ *
+ * @author Kovalov Illia
+ * @since 5.3.0
  */
 @Factory
 public final class RedisAsyncConnectionPoolFactory {
-    private final BeanLocator beanLocator;
-    private final DefaultRedisCacheConfiguration defaultRedisCacheConfiguration;
-    private final DefaultRedisConnectionPoolConfiguration defaultRedisConnectionPoolConfiguration;
 
-    public RedisAsyncConnectionPoolFactory(
+    @Singleton
+    public AsyncPool<StatefulConnection<byte[], byte[]>> getAsyncPool(
             DefaultRedisCacheConfiguration defaultRedisCacheConfiguration,
             BeanLocator beanLocator,
             DefaultRedisConnectionPoolConfiguration defaultRedisConnectionPoolConfiguration
     ) {
-        this.beanLocator = beanLocator;
-        this.defaultRedisCacheConfiguration = defaultRedisCacheConfiguration;
-        this.defaultRedisConnectionPoolConfiguration = defaultRedisConnectionPoolConfiguration;
-    }
-
-    @Singleton
-    public AsyncPool<StatefulConnection<byte[], byte[]>> getAsyncPool() {
         Optional<String> server = defaultRedisCacheConfiguration.getServer();
-        AbstractRedisClient client = RedisConnectionUtil.findClient(this.beanLocator, server, "No Redis server configured to allow caching");
+        AbstractRedisClient client = RedisConnectionUtil.findClient(beanLocator, server, "No Redis server configured to allow caching");
         BoundedPoolConfig asyncConfig = defaultRedisConnectionPoolConfiguration.getBoundedPoolConfig();
         CompletionStage<BoundedAsyncPool<StatefulConnection<byte[], byte[]>>> stage =  AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(() -> {
                     if (client instanceof RedisClusterClient) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -27,6 +27,7 @@ import io.micronaut.configuration.lettuce.RedisSetting;
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
@@ -158,6 +159,38 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
                 redisStringCommands,
                 redisKeyCommands,
                 value);
+    }
+
+    @Override
+    @NonNull
+    @SuppressWarnings("java:S1185") // This is here for binary compatibility
+    public <T> Optional<T> get(Object key, Argument<T> requiredType) {
+        return super.get(key, requiredType);
+    }
+
+    @Override
+    @SuppressWarnings("java:S1185") // This is here for binary compatibility
+    public void put(Object key, Object value) {
+        super.put(key, value);
+    }
+
+    @Override
+    @NonNull
+    @SuppressWarnings("java:S1185") // This is here for binary compatibility
+    public <T> Optional<T> putIfAbsent(Object key, T value) {
+        return super.putIfAbsent(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("java:S1185") // This is here for binary compatibility
+    protected String getKeysPattern() {
+        return super.getKeysPattern();
+    }
+
+    @Override
+    @SuppressWarnings("java:S1185") // This is here for binary compatibility
+    protected byte[] serializeKey(Object key) {
+        return super.serializeKey(key);
     }
 
     @PreDestroy

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
  * An implementation of {@link SyncCache} for Lettuce / Redis using connection pooling.
  *
  * @author Graeme Rocher, Kovalov Illia
- * @since 1.0
+ * @since 5.3.0
  */
 @EachBean(RedisCacheConfiguration.class)
 @Requires(classes = SyncCache.class, property = RedisSetting.REDIS_POOL + ".enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.FALSE)


### PR DESCRIPTION
This addresses the feedback from @sdelamo in #273

One items remains:

- [don't use Optional as method parameter](https://github.com/micronaut-projects/micronaut-redis/pull/273\#discussion_r826692810)

Whilst I agree, this would mean changing every method in that class to use String and check for null.  How strongly do we want this change? It would also require a major release as that class is public

