### PR TITLE
fix: restricting embedded Redis server to only listen on localhost

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
@@ -26,8 +26,11 @@ import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.io.socket.SocketUtils;
 import io.micronaut.core.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import redis.embedded.RedisServer;
 import redis.embedded.RedisServerBuilder;
+import redis.embedded.exceptions.RedisBuildingException;
 
 import javax.annotation.PreDestroy;
 import java.io.Closeable;
@@ -44,6 +47,8 @@ import java.util.Optional;
 @Requires(beans = AbstractRedisConfiguration.class)
 @Factory
 public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRedisConfiguration>, Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedRedisServer.class);
 
     private static final String DEFAULT_MAXMEMORY_SETTING = "maxmemory 256M";
     private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1 ::1";
@@ -70,16 +75,18 @@ public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRed
             RedisURI redisURI = uri.get();
             port = redisURI.getPort();
             host = redisURI.getHost();
-
         }
         if (StringUtils.isNotEmpty(host) && host.equals("localhost") && SocketUtils.isTcpPortAvailable(port)) {
             RedisServerBuilder builder = embeddedConfiguration.builder;
             builder.port(port);
-            builder.setting(DEFAULT_MAXMEMORY_SETTING);
-            builder.setting(DEFAULT_BIND_SETTING);
+            try {
+                builder.setting(DEFAULT_MAXMEMORY_SETTING);
+                builder.setting(DEFAULT_BIND_SETTING);
+            } catch (RedisBuildingException e) {
+                LOGGER.debug("Embedded settings failed as config file is present");
+            }
             redisServer = builder.build();
             redisServer.start();
-
         }
         return configuration;
     }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRedisConfiguration>, Closeable {
 
     private static final String DEFAULT_MAXMEMORY_SETTING = "maxmemory 256M";
-    private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1";
+    private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1 ::1";
 
     private final Configuration embeddedConfiguration;
     private RedisServer redisServer;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/test/EmbeddedRedisServer.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRedisConfiguration>, Closeable {
 
     private static final String DEFAULT_MAXMEMORY_SETTING = "maxmemory 256M";
+    private static final String DEFAULT_BIND_SETTING = "bind 127.0.0.1";
+
     private final Configuration embeddedConfiguration;
     private RedisServer redisServer;
 
@@ -74,6 +76,7 @@ public class EmbeddedRedisServer implements BeanCreatedEventListener<AbstractRed
             RedisServerBuilder builder = embeddedConfiguration.builder;
             builder.port(port);
             builder.setting(DEFAULT_MAXMEMORY_SETTING);
+            builder.setting(DEFAULT_BIND_SETTING);
             redisServer = builder.build();
             redisServer.start();
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -1,0 +1,21 @@
+This section documents breaking changes between versions
+
+== 5.3.0
+
+- The embedded Redis server that can be used for testing has been changed to only bind to localhost.
+
+If you wish to revert to the previous behavior, you will need to use a configuration file specified in your test specific `application.yml` file.
+
+[source,plain]
+.embedded-redis.conf
+----
+maxmemory 256M
+----
+
+[source,yaml]
+.test-application.yml
+----
+redis:
+  embedded:
+    config-file: '/full/path/to/embedded-redis.conf'
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -7,3 +7,6 @@ cache: Redis for Caching
 sessions: Session State with Redis
 graalvm: GraalVM support
 repository: Repository
+appendix:
+  title: Appendices
+  breaks: Breaking Changes


### PR DESCRIPTION
A reproduction of #193 I can iterate on in CI to see if I can find the failures