### PR TITLE
Use getHost instead of getContainerIpAddress

### DIFF
--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/session/SessionSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/session/SessionSpec.groovy
@@ -59,7 +59,7 @@ class SessionSpec extends Specification  implements TestPropertyProvider {
     Map<String, String> getProperties() {
         redis.start()
         return [
-                'redis.uri': 'redis://' + redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379)
+                'redis.uri': 'redis://' + redis.getHost() + ":" + redis.getMappedPort(6379)
         ]
     }
 


### PR DESCRIPTION
getContainerIpAddress is deprecated
