### PR TITLE
fix: add proper requirements to RedisAsyncConnectionPoolFactory

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
@@ -28,6 +28,7 @@ import io.micronaut.configuration.lettuce.DefaultRedisConnectionPoolConfiguratio
 import io.micronaut.configuration.lettuce.RedisConnectionUtil;
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.exceptions.ConfigurationException;
 import jakarta.inject.Singleton;
 
@@ -45,6 +46,7 @@ import java.util.concurrent.CompletionStage;
 public final class RedisAsyncConnectionPoolFactory {
 
     @Singleton
+    @Requires(beans = {DefaultRedisCacheConfiguration.class, DefaultRedisConnectionPoolConfiguration.class})
     public AsyncPool<StatefulConnection<byte[], byte[]>> getAsyncPool(
             DefaultRedisCacheConfiguration defaultRedisCacheConfiguration,
             BeanLocator beanLocator,

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
@@ -13,7 +13,6 @@ import io.micronaut.core.type.Argument
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.redis.test.RedisContainerUtils
 import io.micronaut.runtime.ApplicationConfiguration
-import spock.lang.Specification
 
 import java.nio.charset.Charset
 
@@ -30,9 +29,9 @@ class RedisPoolCacheSpec extends RedisSpec {
         ] + options).environments("test").eagerInitSingletons(eagerInit).start()
     }
 
-    void "can be disabled"() {
+    void "can be disabled where initialization is #description"() {
         setup:
-        ApplicationContext applicationContext = createApplicationContext('redis.pool.enabled': 'false')
+        ApplicationContext applicationContext = createApplicationContext('redis.pool.enabled': 'false', eager)
 
         when:
         applicationContext.getBean(RedisConnectionPoolCache, Qualifiers.byName("test"))
@@ -42,20 +41,11 @@ class RedisPoolCacheSpec extends RedisSpec {
 
         cleanup:
         applicationContext.stop()
-    }
 
-    void "can be disabled with eager init enabled"() {
-        setup:
-        ApplicationContext applicationContext = createApplicationContext('redis.pool.enabled': 'false', true)
-
-        when:
-        applicationContext.getBean(RedisConnectionPoolCache, Qualifiers.byName("test"))
-
-        then:
-        thrown NoSuchBeanException
-
-        cleanup:
-        applicationContext.stop()
+        where:
+        eager | description
+        true  | 'eager'
+        false | 'lazy'
     }
 
     void "accepts configuration"() {


### PR DESCRIPTION
When using eager initialization of singletons, Micronaut will try to
create the `AsyncPool` even if its dependents do not exist
