### PR TITLE
Support custom RedisCodec Bean injection

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -173,5 +173,20 @@
     "type": "io.micronaut.configuration.lettuce.session.RedisSessionStore",
     "member": "Constructor io.micronaut.configuration.lettuce.session.RedisSessionStore(io.micronaut.session.SessionIdGenerator,io.micronaut.configuration.lettuce.session.RedisHttpSessionConfiguration,io.micronaut.context.BeanLocator,io.micronaut.core.serialize.ObjectSerializer,java.util.concurrent.ExecutorService,io.micronaut.context.event.ApplicationEventPublisher)",
     "reason": "We require the Conversion Service for Micronaut 4.0.0"
+  },
+  {
+    "type": "io.micronaut.configuration.lettuce.AbstractRedisClientFactory",
+    "member": "Constructor io.micronaut.configuration.lettuce.AbstractRedisClientFactory()",
+    "reason": "BeanDefinition changes in Micronaut 4.0.0"
+  },
+  {
+    "type": "io.micronaut.configuration.lettuce.DefaultRedisClientFactory",
+    "member": "Constructor io.micronaut.configuration.lettuce.DefaultRedisClientFactory()",
+    "reason": "BeanDefinition changes in Micronaut 4.0.0"
+  },
+  {
+    "type": "io.micronaut.configuration.lettuce.NamedRedisClientFactory",
+    "member": "Constructor io.micronaut.configuration.lettuce.NamedRedisClientFactory(io.micronaut.context.BeanLocator,io.lettuce.core.resource.ClientResources)",
+    "reason": "BeanDefinition changes in Micronaut 4.0.0"
   }
 ]

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
@@ -30,6 +30,8 @@ import java.util.Optional;
  * Abstract version of a factory class for creating Redis clients.
  *
  * @author Graeme Rocher
+ * @param <K> Key type
+ * @param <V> Value type
  * @since 1.0
  */
 public abstract class AbstractRedisClientFactory<K, V> {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.lettuce;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
 
@@ -31,7 +32,13 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.0
  */
-public abstract class AbstractRedisClientFactory {
+public abstract class AbstractRedisClientFactory<K, V> {
+    private final RedisCodec<K, V> codec;
+
+    protected AbstractRedisClientFactory(RedisCodec<K, V> codec) {
+        this.codec = codec;
+    }
+
     /**
      * Creates the {@link RedisClient} from the configuration.
      *
@@ -70,8 +77,8 @@ public abstract class AbstractRedisClientFactory {
      * @param redisClient The {@link RedisClient}
      * @return The {@link StatefulRedisConnection}
      */
-    public StatefulRedisConnection<String, String> redisConnection(RedisClient redisClient) {
-        return redisClient.connect();
+    public StatefulRedisConnection<K, V> redisConnection(RedisClient redisClient) {
+        return redisClient.connect(codec);
     }
 
     /**
@@ -80,8 +87,8 @@ public abstract class AbstractRedisClientFactory {
      * @param redisClient The {@link RedisClient}
      * @return The {@link StatefulRedisPubSubConnection}
      */
-    public StatefulRedisPubSubConnection<String, String> redisPubSubConnection(RedisClient redisClient) {
-        return redisClient.connectPubSub();
+    public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(RedisClient redisClient) {
+        return redisClient.connectPubSub(codec);
     }
 
     @Nullable

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,14 @@ import java.util.Optional;
  * @since 1.0
  */
 public abstract class AbstractRedisClientFactory<K, V> {
-    private final RedisCodec<K, V> codec;
 
-    protected AbstractRedisClientFactory(RedisCodec<K, V> codec) {
-        this.codec = codec;
+    protected final RedisCodec<K, V> defaultCodec;
+
+    /**
+     * @param defaultCodec The default codec
+     */
+    protected AbstractRedisClientFactory(RedisCodec<K, V> defaultCodec) {
+        this.defaultCodec = defaultCodec;
     }
 
     /**
@@ -77,9 +81,10 @@ public abstract class AbstractRedisClientFactory<K, V> {
      * Creates the {@link StatefulRedisConnection} from the {@link RedisClient}.
      *
      * @param redisClient The {@link RedisClient}
+     * @param codec The codec to use
      * @return The {@link StatefulRedisConnection}
      */
-    public StatefulRedisConnection<K, V> redisConnection(RedisClient redisClient) {
+    public StatefulRedisConnection<K, V> redisConnection(RedisClient redisClient, RedisCodec<K, V> codec) {
         return redisClient.connect(codec);
     }
 
@@ -87,9 +92,10 @@ public abstract class AbstractRedisClientFactory<K, V> {
      * Creates the {@link StatefulRedisPubSubConnection} from the {@link RedisClient}.
      *
      * @param redisClient The {@link RedisClient}
+     * @param codec The codec to use
      * @return The {@link StatefulRedisPubSubConnection}
      */
-    public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(RedisClient redisClient) {
+    public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(RedisClient redisClient, RedisCodec<K, V> codec) {
         return redisClient.connectPubSub(codec);
     }
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -33,6 +33,8 @@ import java.util.List;
  * Factory for the default {@link RedisClient}. Creates the injectable {@link Primary} bean.
  *
  * @author Graeme Rocher
+ * @param <K> Key type
+ * @param <V> Value type
  * @since 1.0
  */
 @Requires(beans = DefaultRedisConfiguration.class)

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,18 +55,28 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
         return super.redisClient(config, defaultClientResources, mutators);
     }
 
-    @Override
+    /**
+     * Creates the {@link StatefulRedisConnection} from the {@link RedisClient}.
+     *
+     * @param redisClient The {@link RedisClient}
+     * @return The {@link StatefulRedisConnection}
+     */
     @Bean(preDestroy = "close")
     @Singleton
     @Primary
     public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient) {
-        return super.redisConnection(redisClient);
+        return super.redisConnection(redisClient, defaultCodec);
     }
 
-    @Override
+    /**
+     * Creates the {@link StatefulRedisPubSubConnection} from the {@link RedisClient}.
+     *
+     * @param redisClient The {@link RedisClient}
+     * @return The {@link StatefulRedisPubSubConnection}
+     */
     @Bean(preDestroy = "close")
     @Singleton
     public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(@Primary RedisClient redisClient) {
-        return super.redisPubSubConnection(redisClient);
+        return super.redisPubSubConnection(redisClient, defaultCodec);
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.lettuce;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
 import io.micronaut.context.annotation.Bean;
@@ -38,7 +39,11 @@ import java.util.List;
 @Singleton
 @Factory
 @Requires(missingProperty = RedisSetting.REDIS_URIS)
-public class DefaultRedisClientFactory extends AbstractRedisClientFactory {
+public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<K, V> {
+
+    public DefaultRedisClientFactory(@Primary RedisCodec<K, V> codec) {
+        super(codec);
+    }
 
     @Bean(preDestroy = "shutdown")
     @Singleton
@@ -52,14 +57,14 @@ public class DefaultRedisClientFactory extends AbstractRedisClientFactory {
     @Bean(preDestroy = "close")
     @Singleton
     @Primary
-    public StatefulRedisConnection<String, String> redisConnection(@Primary RedisClient redisClient) {
+    public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient) {
         return super.redisConnection(redisClient);
     }
 
     @Override
     @Bean(preDestroy = "close")
     @Singleton
-    public StatefulRedisPubSubConnection<String, String> redisPubSubConnection(@Primary RedisClient redisClient) {
+    public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(@Primary RedisClient redisClient) {
         return super.redisPubSubConnection(redisClient);
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisCodecFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisCodecFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 /**
@@ -29,7 +28,7 @@ import jakarta.inject.Singleton;
  */
 @Factory
 public final class DefaultRedisCodecFactory {
-    @Requires(missingBeans = RedisCodec.class)
+
     @Singleton
     @Primary
     public RedisCodec<String, String> stringCodec() {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisCodecFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisCodecFactory.java
@@ -28,7 +28,7 @@ import jakarta.inject.Singleton;
  * @author Jorge F. Sánchez
  */
 @Factory
-public class DefaultRedisCodecFactory {
+public final class DefaultRedisCodecFactory {
     @Requires(missingBeans = RedisCodec.class)
     @Singleton
     @Primary

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisCodecFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisCodecFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce;
+
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+/**
+ * Factory for the default {@link RedisCodec}. Creates the injectable {@link Primary} bean.
+ *
+ * @author Jorge F. Sánchez
+ */
+@Factory
+public class DefaultRedisCodecFactory {
+    @Requires(missingBeans = RedisCodec.class)
+    @Singleton
+    @Primary
+    public RedisCodec<String, String> stringCodec() {
+        return StringCodec.UTF8;
+    }
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.lettuce;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
 import io.micronaut.context.BeanLocator;
@@ -37,7 +38,7 @@ import java.util.List;
  * @since 1.0
  */
 @Factory
-public class NamedRedisClientFactory extends AbstractRedisClientFactory {
+public class NamedRedisClientFactory<K, V> extends AbstractRedisClientFactory<K, V> {
 
     private final BeanLocator beanLocator;
     private final ClientResources defaultClientResources;
@@ -46,7 +47,8 @@ public class NamedRedisClientFactory extends AbstractRedisClientFactory {
      * @param beanLocator The BeanLocator
      * @param defaultClientResources The ClientResources
      */
-    public NamedRedisClientFactory(BeanLocator beanLocator, @Primary @Nullable ClientResources defaultClientResources) {
+    public NamedRedisClientFactory(BeanLocator beanLocator, @Primary @Nullable ClientResources defaultClientResources, @Primary RedisCodec<K, V> codec) {
+        super(codec);
         this.beanLocator = beanLocator;
         this.defaultClientResources = defaultClientResources;
     }
@@ -72,7 +74,7 @@ public class NamedRedisClientFactory extends AbstractRedisClientFactory {
      */
     @Bean(preDestroy = "close")
     @EachBean(NamedRedisServersConfiguration.class)
-    public StatefulRedisConnection<String, String> redisConnection(NamedRedisServersConfiguration config) {
+    public StatefulRedisConnection<K, V> redisConnection(NamedRedisServersConfiguration config) {
         return super.redisConnection(getRedisClient(config));
     }
 
@@ -84,7 +86,7 @@ public class NamedRedisClientFactory extends AbstractRedisClientFactory {
      */
     @Bean(preDestroy = "close")
     @EachBean(NamedRedisServersConfiguration.class)
-    public StatefulRedisPubSubConnection<String, String> redisPubSubConnection(NamedRedisServersConfiguration config) {
+    public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(NamedRedisServersConfiguration config) {
         return super.redisPubSubConnection(getRedisClient(config));
     }
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,8 @@ public class NamedRedisClientFactory<K, V> extends AbstractRedisClientFactory<K,
     @Bean(preDestroy = "close")
     @EachBean(NamedRedisServersConfiguration.class)
     public StatefulRedisConnection<K, V> redisConnection(NamedRedisServersConfiguration config) {
-        return super.redisConnection(getRedisClient(config));
+        RedisCodec<K, V> namedCodec = beanLocator.findBean(RedisCodec.class, Qualifiers.byName(config.getName())).orElse(defaultCodec);
+        return super.redisConnection(getRedisClient(config), namedCodec);
     }
 
     /**
@@ -90,7 +91,8 @@ public class NamedRedisClientFactory<K, V> extends AbstractRedisClientFactory<K,
     @Bean(preDestroy = "close")
     @EachBean(NamedRedisServersConfiguration.class)
     public StatefulRedisPubSubConnection<K, V> redisPubSubConnection(NamedRedisServersConfiguration config) {
-        return super.redisPubSubConnection(getRedisClient(config));
+        RedisCodec<K, V> namedCodec = beanLocator.findBean(RedisCodec.class, Qualifiers.byName(config.getName())).orElse(defaultCodec);
+        return super.redisPubSubConnection(getRedisClient(config), namedCodec);
     }
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
@@ -35,6 +35,8 @@ import java.util.List;
  * A factory bean for constructing {@link RedisClient} instances from {@link NamedRedisServersConfiguration} instances.
  *
  * @author Graeme Rocher
+ * @param <K> Key type
+ * @param <V> Value type
  * @since 1.0
  */
 @Factory
@@ -46,6 +48,7 @@ public class NamedRedisClientFactory<K, V> extends AbstractRedisClientFactory<K,
     /**
      * @param beanLocator The BeanLocator
      * @param defaultClientResources The ClientResources
+     * @param codec The RedisCodec
      */
     public NamedRedisClientFactory(BeanLocator beanLocator, @Primary @Nullable ClientResources defaultClientResources, @Primary RedisCodec<K, V> codec) {
         super(codec);

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/ByteArrayCodecReplacementFactory.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/ByteArrayCodecReplacementFactory.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.configuration.lettuce
+
+import io.lettuce.core.codec.ByteArrayCodec
+import io.lettuce.core.codec.RedisCodec
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Requires(property = "spec.name", value = SPEC_NAME)
+//tag::codecReplacement[]
+@Factory
+class ByteArrayCodecReplacementFactory {
+//end::codecReplacement[]
+
+   static final String SPEC_NAME = "byte-array-codec"
+//tag::codecReplacement2[]
+
+    @Singleton
+    @Replaces(RedisCodec)
+    RedisCodec<byte[], byte[]> redisCodec() {
+        return ByteArrayCodec.INSTANCE
+    }
+}
+//end::codecReplacement2[]

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/NamedCodecFactory.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/NamedCodecFactory.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.configuration.lettuce
+
+import io.lettuce.core.codec.ByteArrayCodec
+import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.codec.StringCodec
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+@Requires(property = "spec.name", value = SPEC_NAME)
+//tag::namedCodec[]
+@Factory
+class NamedCodecFactory {
+//end::namedCodec[]
+
+   static final String SPEC_NAME = "named-codecs"
+//tag::namedCodec2[]
+
+    @Singleton
+    @Named("foo")
+    RedisCodec<byte[], byte[]> fooCodec() {
+        return ByteArrayCodec.INSTANCE
+    }
+
+    @Singleton
+    @Named("bar")
+    RedisCodec<String, String> barCodec() {
+        return StringCodec.ASCII
+    }
+}
+//end::namedCodec2[]

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
@@ -4,12 +4,10 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.sync.RedisCommands
-import io.lettuce.core.codec.ByteArrayCodec
 import io.micrometer.core.instrument.MeterRegistry
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.redis.test.RedisContainerUtils
-import spock.lang.Specification
 
 /**
  * @author Graeme Rocher
@@ -133,8 +131,10 @@ class RedisClientFactorySpec extends RedisSpec {
 
     void "test redis client uses defined codec"() {
         when:
-        ApplicationContext applicationContext = ApplicationContext.run('redis.port': RedisContainerUtils.getRedisPort())
-        applicationContext.registerSingleton(ByteArrayCodec.class, ByteArrayCodec.INSTANCE)
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'spec.name': ByteArrayCodecReplacementFactory.SPEC_NAME,
+                'redis.port': RedisContainerUtils.getRedisPort()
+        )
         StatefulRedisConnection connection = applicationContext.getBean(StatefulRedisConnection)
 
         then:

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisCodecFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisCodecFactorySpec.groovy
@@ -1,11 +1,14 @@
 package io.micronaut.configuration.lettuce
 
-
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.ByteArrayCodec
 import io.lettuce.core.codec.RedisCodec
 import io.lettuce.core.codec.StringCodec
 import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.redis.test.RedisContainerUtils
+import io.netty.handler.codec.EncoderException
 
 /**
  * @author Jorge F. Sánchez
@@ -26,12 +29,60 @@ class RedisCodecFactorySpec extends RedisSpec {
 
     void "test custom RedisCodec is used when provided"() {
         when:
-        final applicationContext = ApplicationContext.run('redis.port': RedisContainerUtils.getRedisPort())
+        final applicationContext = ApplicationContext.run(
+                'spec.name': ByteArrayCodecReplacementFactory.SPEC_NAME,
+                'redis.port': RedisContainerUtils.getRedisPort()
+        )
         applicationContext.registerSingleton(ByteArrayCodec.class, ByteArrayCodec.INSTANCE)
 
         then:
         applicationContext.getBean(RedisCodec) == ByteArrayCodec.INSTANCE
         applicationContext.findBean(StringCodec).isEmpty()
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    void "test multi redis server codec config"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'spec.name': NamedCodecFactory.SPEC_NAME,
+                'redis.servers.foo.uri': RedisContainerUtils.getRedisPort("redis://localhost"),
+                'redis.servers.foo.client-name': "foo-client-name",
+                'redis.servers.bar.uri': RedisContainerUtils.getRedisPort("redis://localhost")
+        )
+
+        when: "get foo connection which accepts bytes (see NamedCodecFactory)"
+        StatefulRedisConnection fooConnection = applicationContext.getBean(StatefulRedisConnection, Qualifiers.byName("foo"))
+
+        then:
+        final fooKey = "foo".bytes
+        final fooValue = "bar".bytes
+        RedisCommands<byte[], byte[]> fooCommands = fooConnection.sync()
+        fooCommands.set(fooKey, fooValue)
+        fooCommands.get(fooKey) == fooValue
+
+        when: 'we send the wrong datatype for the codec'
+        fooCommands.set("this", "should fail")
+
+        then:
+        thrown(EncoderException)
+
+        when: "get bar connection which accepts Strings (see NamedCodecFactory)"
+        StatefulRedisConnection barConnection = applicationContext.getBean(StatefulRedisConnection, Qualifiers.byName("bar"))
+
+        then:
+        final barKey = "foo"
+        final barValue = "bar"
+        RedisCommands<String, String> barCommands = barConnection.sync()
+        barCommands.set(barKey, barValue)
+        barCommands.get(barKey) == barValue
+
+        when: 'we send the wrong datatypes for the codec'
+        barCommands.set("this".length(), "should fail".bytes)
+
+        then:
+        thrown(EncoderException)
 
         cleanup:
         applicationContext.stop()

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisCodecFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisCodecFactorySpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.configuration.lettuce
+
+
+import io.lettuce.core.codec.ByteArrayCodec
+import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.codec.StringCodec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.redis.test.RedisContainerUtils
+
+/**
+ * @author Jorge F. Sánchez
+ */
+class RedisCodecFactorySpec extends RedisSpec {
+
+    void "test StringCodec is used by default"() {
+        when:
+        final applicationContext = ApplicationContext.run('redis.port': RedisContainerUtils.getRedisPort())
+        final codec = applicationContext.getBean(RedisCodec)
+
+        then:
+        codec instanceof StringCodec
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    void "test custom RedisCodec is used when provided"() {
+        when:
+        final applicationContext = ApplicationContext.run('redis.port': RedisContainerUtils.getRedisPort())
+        applicationContext.registerSingleton(ByteArrayCodec.class, ByteArrayCodec.INSTANCE)
+
+        then:
+        applicationContext.getBean(RedisCodec) == ByteArrayCodec.INSTANCE
+        applicationContext.findBean(StringCodec).isEmpty()
+
+        cleanup:
+        applicationContext.stop()
+    }
+}

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -36,6 +36,18 @@ In which case the same beans will be created for each entry under `redis.servers
 
 The above example will inject the connection named `foo`.
 
+=== Named connection codec configuration
+
+When using named redis connections, you can change the codec for each connection by supplying a named RedisCodec bean.
+For example:
+
+.Supply different codecs for named connections
+[source,groovy]
+----
+include::{testsredis}/NamedCodecFactory.groovy[tags=namedCodec, indent=0]
+include::{testsredis}/NamedCodecFactory.groovy[tags=namedCodec2, indent=0]
+----
+
 == Redis Health Checks
 
 When the `redis-lettuce` module is activated a api:configuration.lettuce.health.RedisHealthIndicator[] is activated resulting in the `/health` endpoint and https://docs.micronaut.io/latest/api/io/micronaut/health/CurrentHealthStatus.html[CurrentHealthStatus] interface resolving the health of the Redis connection or connections.

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -78,3 +78,15 @@ include::{testsredis}/RedisClientFactorySpec.groovy[tags=commands, indent=0]
 ----
 
 NOTE: The Lettuce driver's `StatefulRedisConnection` interface is designed to be long-lived and there is no need to close the connection. It will be closed automatically when the application shuts down.
+
+=== Redis codec configuration
+
+By default, a StringCodec is used for redis connections.
+This can be configured by supplying your own Factory that replaces the default one.
+
+.Configuring a custom RedisCodecFactory
+[source,groovy]
+----
+include::{testsredis}/ByteArrayCodecReplacementFactory.groovy[tags=codecReplacement, indent=0]
+include::{testsredis}/ByteArrayCodecReplacementFactory.groovy[tags=codecReplacement2, indent=0]
+----


### PR DESCRIPTION
This supercedes the work done by @jfsanchez91 in https://github.com/micronaut-projects/micronaut-redis/pull/342

It is an attempt to add a method for users to specify the codec to use for named redis connections, falling back to the default one if a named codec is not provided