### PR TITLE
MasterReplica and ReadFrom Support

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.lettuce;
 
+import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisURI;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.naming.Named;
@@ -35,6 +36,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     private Integer ioThreadPoolSize;
     private Integer computationThreadPoolSize;
     private String name;
+    private ReadFrom readFrom;
 
     /**
      * Constructor.
@@ -142,5 +144,21 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * @return Get the ReadFrom settings for the read replicas.
+     */
+    public ReadFrom getReadFrom() {
+        return readFrom;
+    }
+
+    /**
+     * Sets the read from property.
+     *
+     * @param readFrom The name of the bean
+     */
+    public void setReadFrom(String readFrom) {
+        this.readFrom = ReadFrom.valueOf(readFrom);
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.lettuce;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisURI;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.Named;
 import java.net.URI;
 import java.util.Arrays;
@@ -85,6 +86,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
 
     /**
      * @return Get the Redis URIs for read replicas.
+     * @since 6.5.0
      */
     public List<RedisURI> getReplicaUris() {
         return replicaUris;
@@ -94,8 +96,9 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * Sets the Replica Redis URIs for read replica configuration.
      *
      * @param uris The URI
+     * @since 6.5.0
      */
-    public void setReplicaUris(URI... uris) {
+    public void setReplicaUris(@NonNull URI... uris) {
         this.replicaUris = Arrays.stream(uris).map(RedisURI::create).collect(Collectors.toList());
     }
 
@@ -164,24 +167,25 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     }
 
     /**
+     *
+     * See {@link io.lettuce.core.ReadFrom}.
+     *
      * @return Get the ReadFrom settings for the read replicas.
-     *
-     * {@link io.lettuce.core.ReadFrom}
-     *
+     * @since 6.5.0
      */
-    public ReadFrom getReadFrom() {
-        return readFrom;
+    public Optional<ReadFrom> getReadFrom() {
+        return Optional.ofNullable(readFrom);
     }
 
     /**
-     * Sets the read from property.
+     * Sets the read from property by name.
+     *
+     * See {@link io.lettuce.core.ReadFrom#valueOf(String)}
      *
      * @param readFrom The value of the ReadFrom setting to use.
-     *
-     * {@link io.lettuce.core.ReadFrom#valueOf(String)}
-     *
+     * @since 6.5.0
      */
-    public void setReadFrom(String readFrom) {
+    public void setReadFrom(@NonNull String readFrom) {
         this.readFrom = ReadFrom.valueOf(readFrom);
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -33,6 +33,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
 
     private RedisURI uri;
     private List<RedisURI> uris = Collections.emptyList();
+    private List<RedisURI> replicaUris = Collections.emptyList();
     private Integer ioThreadPoolSize;
     private Integer computationThreadPoolSize;
     private String name;
@@ -80,6 +81,22 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      */
     public void setUris(URI... uris) {
         this.uris = Arrays.stream(uris).map(RedisURI::create).collect(Collectors.toList());
+    }
+
+    /**
+     * @return Get the Redis URIs for read replicas.
+     */
+    public List<RedisURI> getReplicaUris() {
+        return replicaUris;
+    }
+
+    /**
+     * Sets the Replica Redis URIs for read replica configuration.
+     *
+     * @param uris The URI
+     */
+    public void setReplicaUris(URI... uris) {
+        this.replicaUris = Arrays.stream(uris).map(RedisURI::create).collect(Collectors.toList());
     }
 
     /**
@@ -148,6 +165,9 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
 
     /**
      * @return Get the ReadFrom settings for the read replicas.
+     *
+     * {@link io.lettuce.core.ReadFrom}
+     *
      */
     public ReadFrom getReadFrom() {
         return readFrom;
@@ -156,7 +176,10 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     /**
      * Sets the read from property.
      *
-     * @param readFrom The name of the bean
+     * @param readFrom The value of the ReadFrom setting to use.
+     *
+     * {@link io.lettuce.core.ReadFrom#valueOf(String)}
+     *
      */
     public void setReadFrom(String readFrom) {
         this.readFrom = ReadFrom.valueOf(readFrom);

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -16,10 +16,14 @@
 package io.micronaut.configuration.lettuce;
 
 import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
+import io.micronaut.context.BeanLocator;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
@@ -27,7 +31,10 @@ import io.micronaut.context.annotation.Requires;
 
 import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Factory for the default {@link RedisClient}. Creates the injectable {@link Primary} bean.
@@ -43,8 +50,11 @@ import java.util.List;
 @Requires(missingProperty = RedisSetting.REDIS_URIS)
 public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<K, V> {
 
-    public DefaultRedisClientFactory(@Primary RedisCodec<K, V> codec) {
+    private final BeanLocator beanLocator;
+
+    public DefaultRedisClientFactory(@Primary RedisCodec<K, V> codec, BeanLocator beanLocator) {
         super(codec);
+        this.beanLocator = beanLocator;
     }
 
     @Bean(preDestroy = "shutdown")
@@ -65,7 +75,25 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
     @Singleton
     @Primary
     public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient) {
-        return super.redisConnection(redisClient, defaultCodec);
+        Optional<AbstractRedisConfiguration> config = beanLocator.findBean(AbstractRedisConfiguration.class);
+
+        if (config.isPresent() && config.get().getReplicaUris().size() > 0) {
+            List<RedisURI> uris = new ArrayList(config.get().getReplicaUris());
+            uris.add(config.get().getUri().get());
+
+            StatefulRedisMasterReplicaConnection connection = MasterReplica.connect(
+                redisClient,
+                defaultCodec,
+                uris
+            );
+            if (config.get().getReadFrom() != null) {
+                connection.setReadFrom(config.get().getReadFrom());
+            }
+
+            return connection;
+        } else {
+            return super.redisConnection(redisClient, defaultCodec);
+        }
     }
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -72,7 +72,7 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
     @Singleton
     @Primary
     public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient, AbstractRedisConfiguration config) {
-        if (!config.getReplicaUris().isEmpty()) {
+        if (config.getUri().isPresent() && !config.getReplicaUris().isEmpty()) {
             List<RedisURI> uris = new ArrayList<>(config.getReplicaUris());
             uris.add(config.getUri().get());
 
@@ -81,8 +81,8 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
                 defaultCodec,
                 uris
             );
-            if (config.getReadFrom() != null) {
-                connection.setReadFrom(config.getReadFrom());
+            if (config.getReadFrom().isPresent()) {
+                connection.setReadFrom(config.getReadFrom().get());
             }
 
             return connection;
@@ -98,8 +98,6 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
      * @return The {@link StatefulRedisConnection}
      * @deprecated use {@link #redisConnection(RedisClient, AbstractRedisConfiguration)} instead
      */
-    @Bean(preDestroy = "close")
-    @Singleton
     @Deprecated(since = "6.5.0", forRemoval = true)
     public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient) {
         return super.redisConnection(redisClient, defaultCodec);

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -64,6 +64,7 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
      * Creates the {@link StatefulRedisConnection} from the {@link RedisClient}.
      *
      * @param redisClient The {@link RedisClient}
+     * @param config The config.
      * @return The {@link StatefulRedisConnection}
      * @since 6.5.0
      */

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClientFactory.java
@@ -23,7 +23,6 @@ import io.lettuce.core.masterreplica.MasterReplica;
 import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
-import io.micronaut.context.BeanLocator;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
@@ -34,7 +33,6 @@ import jakarta.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Factory for the default {@link RedisClient}. Creates the injectable {@link Primary} bean.
@@ -50,11 +48,8 @@ import java.util.Optional;
 @Requires(missingProperty = RedisSetting.REDIS_URIS)
 public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<K, V> {
 
-    private final BeanLocator beanLocator;
-
-    public DefaultRedisClientFactory(@Primary RedisCodec<K, V> codec, BeanLocator beanLocator) {
+    public DefaultRedisClientFactory(@Primary RedisCodec<K, V> codec) {
         super(codec);
-        this.beanLocator = beanLocator;
     }
 
     @Bean(preDestroy = "shutdown")
@@ -70,30 +65,43 @@ public class DefaultRedisClientFactory<K, V> extends AbstractRedisClientFactory<
      *
      * @param redisClient The {@link RedisClient}
      * @return The {@link StatefulRedisConnection}
+     * @since 6.5.0
      */
     @Bean(preDestroy = "close")
     @Singleton
     @Primary
-    public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient) {
-        Optional<AbstractRedisConfiguration> config = beanLocator.findBean(AbstractRedisConfiguration.class);
+    public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient, AbstractRedisConfiguration config) {
+        if (!config.getReplicaUris().isEmpty()) {
+            List<RedisURI> uris = new ArrayList<>(config.getReplicaUris());
+            uris.add(config.getUri().get());
 
-        if (config.isPresent() && config.get().getReplicaUris().size() > 0) {
-            List<RedisURI> uris = new ArrayList(config.get().getReplicaUris());
-            uris.add(config.get().getUri().get());
-
-            StatefulRedisMasterReplicaConnection connection = MasterReplica.connect(
+            StatefulRedisMasterReplicaConnection<K, V> connection = MasterReplica.connect(
                 redisClient,
                 defaultCodec,
                 uris
             );
-            if (config.get().getReadFrom() != null) {
-                connection.setReadFrom(config.get().getReadFrom());
+            if (config.getReadFrom() != null) {
+                connection.setReadFrom(config.getReadFrom());
             }
 
             return connection;
         } else {
             return super.redisConnection(redisClient, defaultCodec);
         }
+    }
+
+    /**
+     * Creates the {@link StatefulRedisConnection} from the {@link RedisClient}.
+     *
+     * @param redisClient The {@link RedisClient}
+     * @return The {@link StatefulRedisConnection}
+     * @deprecated use {@link #redisConnection(RedisClient, AbstractRedisConfiguration)} instead
+     */
+    @Bean(preDestroy = "close")
+    @Singleton
+    @Deprecated(since = "6.5.0", forRemoval = true)
+    public StatefulRedisConnection<K, V> redisConnection(@Primary RedisClient redisClient) {
+        return super.redisConnection(redisClient, defaultCodec);
     }
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactory.java
@@ -95,8 +95,8 @@ public class DefaultRedisClusterClientFactory {
     @Primary
     public StatefulRedisClusterConnection<String, String> redisConnection(@Primary RedisClusterClient redisClient, @Primary AbstractRedisConfiguration config) {
         StatefulRedisClusterConnection<String, String> connection = redisClient.connect();
-        if (config.getReadFrom() != null) {
-            connection.setReadFrom(config.getReadFrom());
+        if (config.getReadFrom().isPresent()) {
+            connection.setReadFrom(config.getReadFrom().get());
         }
         return connection;
     }
@@ -107,8 +107,6 @@ public class DefaultRedisClusterClientFactory {
      * @return connection
      * @deprecated use {@link #redisConnection(RedisClusterClient, AbstractRedisConfiguration)} instead
      */
-    @Bean(preDestroy = "close")
-    @Singleton
     @Deprecated(since = "6.5.0", forRemoval = true)
     public StatefulRedisClusterConnection<String, String> redisConnection(@Primary RedisClusterClient redisClient) {
         return redisClient.connect();

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactory.java
@@ -86,7 +86,7 @@ public class DefaultRedisClusterClientFactory {
     /**
      * Establish redis connection.
      * @param redisClient client.
-     * @param config config
+     * @param config config.
      * @return connection
      * @since 6.5.0
      */

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisClientFactory.java
@@ -95,14 +95,14 @@ public class NamedRedisClientFactory<K, V> extends AbstractRedisClientFactory<K,
                 namedCodec,
                 uris
             );
-            if (config.getReadFrom() != null) {
-                ((StatefulRedisMasterReplicaConnection<K, V>) connection).setReadFrom(config.getReadFrom());
+            if (config.getReadFrom().isPresent()) {
+                ((StatefulRedisMasterReplicaConnection<K, V>) connection).setReadFrom(config.getReadFrom().get());
             }
         } else {
             connection = super.redisConnection(getRedisClient(config), namedCodec);
 
-            if (connection instanceof StatefulRedisClusterConnection && config.getReadFrom() != null) {
-                ((StatefulRedisClusterConnection<?, ?>) connection).setReadFrom(config.getReadFrom());
+            if (connection instanceof StatefulRedisClusterConnection<?, ?> conn && config.getReadFrom().isPresent()) {
+                conn.setReadFrom(config.getReadFrom().get());
             }
         }
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
@@ -115,15 +115,15 @@ public class RedisConnectionUtil {
         Optional<RedisClusterClient> redisClusterClient = findRedisClusterClient(beanLocator, serverName);
         if (redisClusterClient.isPresent()) {
             StatefulRedisClusterConnection<byte[], byte[]> conn = redisClusterClient.get().connect(ByteArrayCodec.INSTANCE);
-            if (config.isPresent() && config.get().getReadFrom() != null) {
-                conn.setReadFrom(config.get().getReadFrom());
+            if (config.isPresent() && config.get().getReadFrom().isPresent()) {
+                conn.setReadFrom(config.get().getReadFrom().get());
             }
             return conn;
         }
         Optional<RedisClient> redisClient = findRedisClient(beanLocator, serverName);
         if (redisClient.isPresent()) {
-            if (config.isPresent() && config.get().getReplicaUris().size() > 0) {
-                List<RedisURI> uris = new ArrayList(config.get().getReplicaUris());
+            if (config.isPresent() && config.get().getUri().isPresent() && !config.get().getReplicaUris().isEmpty()) {
+                List<RedisURI> uris = new ArrayList<>(config.get().getReplicaUris());
                 uris.add(config.get().getUri().get());
 
                 StatefulRedisMasterReplicaConnection<byte[], byte[]> connection = MasterReplica.connect(
@@ -131,8 +131,8 @@ public class RedisConnectionUtil {
                     ByteArrayCodec.INSTANCE,
                     uris
                 );
-                if (config.get().getReadFrom() != null) {
-                    connection.setReadFrom(config.get().getReadFrom());
+                if (config.get().getReadFrom().isPresent()) {
+                    connection.setReadFrom(config.get().getReadFrom().get());
                 }
 
                 return connection;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
@@ -106,9 +106,15 @@ public class RedisConnectionUtil {
      * @throws ConfigurationException If the connection cannot be found
      */
     public static StatefulConnection<byte[], byte[]> openBytesRedisConnection(BeanLocator beanLocator, Optional<String> serverName, String errorMessage) {
+        Optional<DefaultRedisConfiguration> config = beanLocator.findBean(DefaultRedisConfiguration.class);
         Optional<RedisClusterClient> redisClusterClient = findRedisClusterClient(beanLocator, serverName);
+        findRedisConnection(beanLocator, serverName, "test");
         if (redisClusterClient.isPresent()) {
-            return redisClusterClient.get().connect(ByteArrayCodec.INSTANCE);
+            StatefulRedisClusterConnection<byte[], byte[]> conn = redisClusterClient.get().connect(ByteArrayCodec.INSTANCE);
+            if (config.isPresent() && config.get().getReadFrom() != null) {
+                conn.setReadFrom(config.get().getReadFrom());
+            }
+            return conn;
         }
         Optional<RedisClient> redisClient = findRedisClient(beanLocator, serverName);
         if (redisClient.isPresent()) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisSetting.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisSetting.java
@@ -50,4 +50,12 @@ public interface RedisSetting {
      * Default configuration for Redis caches pool.
      */
     String REDIS_POOL = PREFIX + ".pool";
+    /**
+     * The URIs to the redis read replicas.
+     */
+    String REDIS_REPLICA_URIS = PREFIX + ".replica-uris";
+    /**
+     * The Primary/Replica read-from preference.
+     */
+    String REDIS_READ_FROM = PREFIX + ".read-from";
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisSetting.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisSetting.java
@@ -34,6 +34,10 @@ public interface RedisSetting {
      */
     String REDIS_URIS = PREFIX + ".uris";
     /**
+     * The URIs to the redis read replicas.
+     */
+    String REDIS_REPLICA_URIS = PREFIX + ".replica-uris";
+    /**
      * The named redis servers.
      */
     String REDIS_SERVERS = PREFIX + ".servers";
@@ -50,10 +54,6 @@ public interface RedisSetting {
      * Default configuration for Redis caches pool.
      */
     String REDIS_POOL = PREFIX + ".pool";
-    /**
-     * The URIs to the redis read replicas.
-     */
-    String REDIS_REPLICA_URIS = PREFIX + ".replica-uris";
     /**
      * The Primary/Replica read-from preference.
      */

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.configuration.lettuce.cache;
 
-import io.lettuce.core.ReadFrom;
 import io.micronaut.core.serialize.ObjectSerializer;
 import io.micronaut.runtime.ApplicationConfiguration;
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.lettuce.cache;
 
+import io.lettuce.core.ReadFrom;
 import io.micronaut.core.serialize.ObjectSerializer;
 import io.micronaut.runtime.ApplicationConfiguration;
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
@@ -19,11 +19,13 @@ import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.support.AsyncConnectionPoolSupport;
 import io.lettuce.core.support.AsyncPool;
 import io.lettuce.core.support.BoundedAsyncPool;
 import io.lettuce.core.support.BoundedPoolConfig;
+import io.micronaut.configuration.lettuce.DefaultRedisConfiguration;
 import io.micronaut.configuration.lettuce.DefaultRedisConnectionPoolConfiguration;
 import io.micronaut.configuration.lettuce.RedisConnectionUtil;
 import io.micronaut.context.BeanLocator;
@@ -46,9 +48,10 @@ import java.util.concurrent.CompletionStage;
 public final class RedisAsyncConnectionPoolFactory {
 
     @Singleton
-    @Requires(beans = {DefaultRedisCacheConfiguration.class, DefaultRedisConnectionPoolConfiguration.class})
+    @Requires(beans = {DefaultRedisCacheConfiguration.class, DefaultRedisConnectionPoolConfiguration.class, DefaultRedisConfiguration.class})
     public AsyncPool<StatefulConnection<byte[], byte[]>> getAsyncPool(
             DefaultRedisCacheConfiguration defaultRedisCacheConfiguration,
+            DefaultRedisConfiguration defaultRedisConfiguration,
             BeanLocator beanLocator,
             DefaultRedisConnectionPoolConfiguration defaultRedisConnectionPoolConfiguration
     ) {
@@ -57,7 +60,13 @@ public final class RedisAsyncConnectionPoolFactory {
         BoundedPoolConfig asyncConfig = defaultRedisConnectionPoolConfiguration.getBoundedPoolConfig();
         CompletionStage<BoundedAsyncPool<StatefulConnection<byte[], byte[]>>> stage =  AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(() -> {
                     if (client instanceof RedisClusterClient) {
-                        return CompletableFuture.completedFuture(((RedisClusterClient) client).connect(new ByteArrayCodec()));
+                        StatefulRedisClusterConnection<byte[], byte[]> connection = ((RedisClusterClient) client).connect(new ByteArrayCodec());
+
+                        if (defaultRedisConfiguration.getReadFrom() != null) {
+                            connection.setReadFrom(defaultRedisConfiguration.getReadFrom());
+                        }
+
+                        return CompletableFuture.completedFuture(connection);
                     }
                     if (client instanceof RedisClient) {
                         return CompletableFuture.completedFuture(((RedisClient) client).connect(new ByteArrayCodec()));

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
@@ -67,14 +67,14 @@ public final class RedisAsyncConnectionPoolFactory {
                     if (client instanceof RedisClusterClient) {
                         StatefulRedisClusterConnection<byte[], byte[]> connection = ((RedisClusterClient) client).connect(new ByteArrayCodec());
 
-                        if (defaultRedisConfiguration.getReadFrom() != null) {
-                            connection.setReadFrom(defaultRedisConfiguration.getReadFrom());
+                        if (defaultRedisConfiguration.getReadFrom().isPresent()) {
+                            connection.setReadFrom(defaultRedisConfiguration.getReadFrom().get());
                         }
 
                         return CompletableFuture.completedFuture(connection);
                     }
                     if (client instanceof RedisClient) {
-                        if (!defaultRedisConfiguration.getReplicaUris().isEmpty()) {
+                        if (defaultRedisConfiguration.getUri().isPresent() && !defaultRedisConfiguration.getReplicaUris().isEmpty()) {
                             List<RedisURI> uris = new ArrayList<>(defaultRedisConfiguration.getReplicaUris());
                             uris.add(defaultRedisConfiguration.getUri().get());
 
@@ -83,8 +83,8 @@ public final class RedisAsyncConnectionPoolFactory {
                                 new ByteArrayCodec(),
                                 uris
                             );
-                            if (defaultRedisConfiguration.getReadFrom() != null) {
-                                connection.setReadFrom(defaultRedisConfiguration.getReadFrom());
+                            if (defaultRedisConfiguration.getReadFrom().isPresent()) {
+                                connection.setReadFrom(defaultRedisConfiguration.getReadFrom().get());
                             }
 
                             return CompletableFuture.completedFuture(connection);

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisReplicaClientFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisReplicaClientFactorySpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.configuration.lettuce
+
+import io.lettuce.core.ReadFrom
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection
+import io.micronaut.context.ApplicationContext
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+class RedisReplicaClientFactorySpec extends RedisReplicaSpec {
+
+    void "test redis server config with replica uris"() {
+        when:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'redis.uri': primaryUri,
+                'redis.replica-uris': redisReplicaUris,
+        )
+        StatefulRedisConnection connection = applicationContext.getBean(StatefulRedisConnection)
+
+        then:
+        // tag::commands[]
+        RedisCommands<String, String> commands = connection.sync()
+        commands.set("foo", "bar")
+        commands.get("foo") == "bar"
+        // end::commands[]
+        connection instanceof StatefulRedisMasterReplicaConnection
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    void "test redis server config with read-from"() {
+        when:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'redis.uri': primaryUri,
+                'redis.replica-uris': redisReplicaUris,
+                'redis.read-from': "replicaPreferred"
+        )
+        StatefulRedisConnection connection = applicationContext.getBean(StatefulRedisConnection)
+
+        then:
+        // tag::commands[]
+        RedisCommands<String, String> commands = connection.sync()
+        commands.set("foo", "bar")
+        commands.get("foo") == "bar"
+        // end::commands[]
+        connection instanceof StatefulRedisMasterReplicaConnection
+        ((StatefulRedisMasterReplicaConnection) connection).readFrom == ReadFrom.REPLICA_PREFERRED
+
+        cleanup:
+        applicationContext.stop()
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisReplicaSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisReplicaSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.configuration.lettuce
+
+import groovy.transform.CompileStatic
+import io.micronaut.redis.test.RedisReplicaContainerUtils
+import spock.lang.Specification
+
+@CompileStatic
+abstract class RedisReplicaSpec extends Specification {
+
+    def cleanupSpec() {
+        RedisReplicaContainerUtils.close();
+    }
+
+    List<String> getRedisReplicaUris() {
+        return RedisReplicaContainerUtils.getRedisReplicaUris()
+    }
+
+    String getPrimaryUri() {
+        return RedisReplicaContainerUtils.getRedisPrimaryUri()
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisClusterCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisClusterCacheSpec.groovy
@@ -1,0 +1,122 @@
+package io.micronaut.configuration.lettuce.cache
+
+import io.lettuce.core.ReadFrom
+import io.lettuce.core.api.StatefulConnection
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisStringAsyncCommands
+import io.lettuce.core.cluster.RedisClusterClient
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.protocol.AsyncCommand
+import io.lettuce.core.protocol.RedisCommand
+import io.micronaut.configuration.lettuce.RedisClusterSpec
+import io.micronaut.configuration.lettuce.RedisSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanLocator
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.redis.test.RedisContainerUtils
+import io.micronaut.runtime.ApplicationConfiguration
+import spock.lang.Requires
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import java.nio.charset.Charset
+import java.util.concurrent.ExecutionException
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+class RedisClusterCacheSpec extends RedisClusterSpec {
+
+    ApplicationContext createApplicationContext() {
+        ApplicationContext.run([
+                'redis.uris': redisClusterUris,
+                'redis.read-from': "replicaPreferred",
+                'redis.caches.test.enabled': 'true'
+        ])
+    }
+
+    void "test read/write object from redis sync cache with read-from"() {
+        setup:
+        ApplicationContext applicationContext = createApplicationContext()
+        RedisClusterClient client = applicationContext.getBean(RedisClusterClient)
+        fixPartitions(client)
+
+        when:
+        RedisCache redisCache = applicationContext.getBean(RedisCache, Qualifiers.byName("test"))
+        StatefulConnection connection = redisCache.getNativeCache()
+
+        then:
+        redisCache != null
+        connection instanceof StatefulRedisClusterConnection
+        ((StatefulRedisClusterConnection) connection).getReadFrom() == ReadFrom.REPLICA_PREFERRED
+
+
+        when:
+        redisCache.put("test", new Foo(name: "test"))
+        redisCache.put("two", new Foo(name: "two"))
+        redisCache.put("test-list", [new Foo(name: "abc")] as List<Foo>)
+        redisCache.put("three", 3)
+        redisCache.put("four", "four")
+        Foo foo = redisCache.get("test", Foo).get()
+        then:
+        foo != null
+        foo.name == 'test'
+        redisCache.async().get("two", Foo.class).get().get().name == "two"
+        redisCache.async().get("three", Integer.class).get().get() == 3
+        redisCache.async().get("four", String.class).get().get() == "four"
+        redisCache.async().get("test-list", Argument.listOf(Foo)).get().get().get(0) instanceof Foo
+        redisCache.async().get("test-list", Argument.listOf(Foo)).get().get().get(0).name == "abc"
+
+        when:
+        redisCache.invalidate("test")
+
+        then:
+        !redisCache.get("test", Foo).isPresent()
+        !redisCache.async().get("test", Foo).get().isPresent()
+        redisCache.get("two", Foo).isPresent()
+
+        when:
+        redisCache.async().put("three", new Foo(name: "three")).get()
+        Foo two = redisCache.async().get("two", Foo, {-> new Foo(name: "two")}).get()
+        Foo created = redisCache.async().get("new", Foo, {-> new Foo(name: "new")}).get()
+
+        then:
+        two != null
+        created != null
+        created.name == "new"
+        redisCache.get("three", Foo).isPresent()
+        redisCache.async().get("three", Foo).get().isPresent()
+        redisCache.get("new", Foo).isPresent()
+
+        when:
+        redisCache.async().invalidate("three").get()
+
+        then:
+        !redisCache.async().get("three", Foo).get().isPresent()
+        redisCache.get("new", Foo).isPresent()
+
+        when:
+        redisCache.invalidateAll()
+
+        then:
+        !redisCache.get("test", Foo).isPresent()
+        !redisCache.get("two", Foo).isPresent()
+        !redisCache.get("new", Foo).isPresent()
+        !redisCache.get("four", Foo).isPresent()
+
+        then:
+        // invalidate an empty cache should not fail
+        redisCache.invalidateAll()
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    static class Foo implements Serializable {
+        String name
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisClusterCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisClusterCacheSpec.groovy
@@ -2,28 +2,12 @@ package io.micronaut.configuration.lettuce.cache
 
 import io.lettuce.core.ReadFrom
 import io.lettuce.core.api.StatefulConnection
-import io.lettuce.core.api.StatefulRedisConnection
-import io.lettuce.core.api.async.RedisStringAsyncCommands
 import io.lettuce.core.cluster.RedisClusterClient
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
-import io.lettuce.core.protocol.AsyncCommand
-import io.lettuce.core.protocol.RedisCommand
 import io.micronaut.configuration.lettuce.RedisClusterSpec
-import io.micronaut.configuration.lettuce.RedisSpec
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanLocator
-import io.micronaut.context.exceptions.ConfigurationException
-import io.micronaut.core.convert.ConversionService
 import io.micronaut.core.type.Argument
 import io.micronaut.inject.qualifiers.Qualifiers
-import io.micronaut.redis.test.RedisContainerUtils
-import io.micronaut.runtime.ApplicationConfiguration
-import spock.lang.Requires
-
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
-import java.nio.charset.Charset
-import java.util.concurrent.ExecutionException
 
 /**
  * @author Graeme Rocher

--- a/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisReplicaContainerUtils.java
+++ b/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisReplicaContainerUtils.java
@@ -1,0 +1,85 @@
+package io.micronaut.redis.test;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testcontainers.containers.Network.SHARED;
+
+public final class RedisReplicaContainerUtils {
+    public static int REDIS_PORT = 6379;
+    private static String REDIS_DOCKER_NAME = "redis:6.2.6";
+    private static final String PRIMARY_NODE_NAME = "redis-primary";
+    private static final String REPLICA_NODE_NAME = "redis-replica";
+
+    private static final Map<String, Integer> redisReplicaPortMappings = new HashMap<>();
+
+    private RedisReplicaContainerUtils() {
+    }
+
+    private static GenericContainer<?> primaryContainer;
+    private static GenericContainer<?> replicaContainer;
+
+    public static String getRedisPrimaryUri() {
+        int port = startRedis();
+
+        return toRedisUri(port);
+    }
+
+    public static void close() {
+        stopRedis();
+    }
+
+    public static List<String> getRedisReplicaUris() {
+        startRedis();
+        return redisReplicaPortMappings.values().stream().map(RedisReplicaContainerUtils::toRedisUri).toList();
+    }
+
+    public static int startRedis() {
+        if (primaryContainer == null) {
+            primaryContainer = new GenericContainer<>(DockerImageName.parse(REDIS_DOCKER_NAME))
+                .withExposedPorts(REDIS_PORT)
+                .withNetwork(SHARED)
+                .withNetworkAliases(PRIMARY_NODE_NAME)
+                .waitingFor(Wait.forListeningPort());
+            primaryContainer.start();
+        }
+
+        if (replicaContainer == null) {
+            replicaContainer = new GenericContainer<>(DockerImageName.parse(REDIS_DOCKER_NAME))
+                .withExposedPorts(REDIS_PORT)
+                .withNetwork(SHARED)
+                .withNetworkAliases(REPLICA_NODE_NAME)
+                .withCommand(
+                    "redis-server",
+                    "--slaveof",
+                    PRIMARY_NODE_NAME,
+                    String.valueOf(REDIS_PORT)
+                )
+                .waitingFor(Wait.forListeningPort());
+            replicaContainer.start();
+
+            redisReplicaPortMappings.put(REPLICA_NODE_NAME, replicaContainer.getMappedPort(REDIS_PORT));
+        }
+        return primaryContainer.getMappedPort(REDIS_PORT);
+    }
+
+    private static String toRedisUri(Integer port) {
+        return "redis://localhost:" + port;
+    }
+
+    public static void stopRedis() {
+        if (primaryContainer != null) {
+            primaryContainer.stop();
+            primaryContainer = null;
+        }
+        if (replicaContainer != null) {
+            replicaContainer.stop();
+            replicaContainer = null;
+        }
+    }
+}

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -36,6 +36,34 @@ In which case the same beans will be created for each entry under `redis.servers
 
 The above example will inject the connection named `foo`.
 
+=== MasterReplica Configuration
+You can configure a standalone redis instance with replicas by supplying the `redis.replica-uris` setting to list out the location of all replicas.
+
+.MasterReplica Redis Configuration
+[source,yaml]
+----
+redis:
+    uri: redis://localhost
+    replica-uris:
+      - redis://localhost:6578
+    ssl: true
+    timeout: 30s
+----
+
+=== ReadFrom Settings
+For MasterReplica and Cluster configurations the https://github.com/redis/lettuce/wiki/ReadFrom-Settings[ReadFrom Setting] can be configured using the `redis.read-from` setting.
+
+.ReadFrom Redis Configuration
+[source,yaml]
+----
+redis:
+    uris:
+      - redis://localhost
+    read-from: replicaPreferred
+----
+
+This setting accepts a string matching the values accepted in the https://github.com/redis/lettuce/blob/main/src/main/java/io/lettuce/core/ReadFrom.java#L190[ReadFrom.valueOf] method. These are currently `master`, `masterPreferred`, `upstream`, `upstreamPreferred`, `replica`, `replicaPreferred`, `lowestLatency` , `any`, and `anyReplica`.
+
 === Named connection codec configuration
 
 When using named redis connections, you can change the codec for each connection by supplying a named RedisCodec bean.


### PR DESCRIPTION
This PR adds support for using a MasterReplica connection by providing the `redis.replica-uris` setting in combination with the `redis.uri` setting.

It adds support for configuring the Redis ReadFrom settings for MasterReplica and Cluster connections through the `redis.read-from` setting, allowing users to configure how they would like to spread reads across their redis instances.

This implements the enhancement requested in https://github.com/micronaut-projects/micronaut-redis/issues/430