### PR TITLE
Update invalidateAll implementation to use SCAN

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
@@ -53,6 +53,7 @@ public abstract class AbstractRedisCache<C> implements SyncCache<C>, AutoCloseab
     protected final RedisCacheConfiguration redisCacheConfiguration;
     protected final ExpirationAfterWritePolicy expireAfterWritePolicy;
     protected final Long expireAfterAccess;
+    protected final Long invalidateScanCount;
 
     protected AbstractRedisCache(
             DefaultRedisCacheConfiguration defaultRedisCacheConfiguration,
@@ -92,6 +93,8 @@ public abstract class AbstractRedisCache<C> implements SyncCache<C>, AutoCloseab
                 .getExpireAfterAccess()
                 .map(Duration::toMillis)
                 .orElse(defaultRedisCacheConfiguration.getExpireAfterAccess().map(Duration::toMillis).orElse(null));
+
+        this.invalidateScanCount = redisCacheConfiguration.getInvalidateScanCount().orElse(100L);
     }
 
     @Override

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCacheConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.lettuce.cache;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.serialize.ObjectSerializer;
 import io.micronaut.runtime.ApplicationConfiguration;
 
@@ -37,6 +38,7 @@ public abstract class AbstractRedisCacheConfiguration {
     protected Duration expireAfterWrite;
     protected Duration expireAfterAccess;
     protected String expirationAfterWritePolicy;
+    protected Long invalidateScanCount = 100L;
 
     /**
      * Constructor.
@@ -133,5 +135,27 @@ public abstract class AbstractRedisCacheConfiguration {
      */
     public void setExpirationAfterWritePolicy(String expirationAfterWritePolicy) {
         this.expirationAfterWritePolicy = expirationAfterWritePolicy;
+    }
+
+    /**
+     * Returns the count used for the scan command in {@link io.micronaut.configuration.lettuce.cache.RedisCache#invalidateAll()}.
+     * See {@link io.lettuce.core.ScanArgs#limit(long)}. Defaults to 100L.
+     *
+     * @return the count setting used in the redis scan in {@link io.micronaut.configuration.lettuce.cache.RedisCache#invalidateAll()}.
+     * @since 6.5.0
+     */
+    public Optional<Long> getInvalidateScanCount() {
+        return Optional.ofNullable(invalidateScanCount);
+    }
+
+    /**
+     * Sets the count used for the scan command in {@link io.micronaut.configuration.lettuce.cache.RedisCache#invalidateAll()}.
+     * See {@link io.lettuce.core.ScanArgs#limit(long)}. Defaults to 100L.
+     *
+     * @param invalidateScanCount the count setting to use with the redis scan in {@link io.micronaut.configuration.lettuce.cache.RedisCache#invalidateAll()}.
+     * @since 6.5.0
+     */
+    public void setInvalidateScanCount(@NonNull Long invalidateScanCount) {
+        this.invalidateScanCount = invalidateScanCount;
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisJsonDeserializerCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisJsonDeserializerCacheSpec.groovy
@@ -12,7 +12,8 @@ class RedisJsonDeserializerCacheSpec extends RedisCacheSpec {
         ApplicationContext.run(
                 'redis.port': RedisContainerUtils.getRedisPort(),
                 'redis.caches.test.enabled': 'true',
-                'redis.caches.test.valueSerializer': 'io.micronaut.jackson.serialize.JacksonObjectSerializer'
+                'redis.caches.test.valueSerializer': 'io.micronaut.jackson.serialize.JacksonObjectSerializer',
+                'redis.caches.test.invalidate-scan-count' : 2
         )
     }
 }

--- a/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisClusterContainerUtils.java
+++ b/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisClusterContainerUtils.java
@@ -69,7 +69,8 @@ public final class RedisClusterContainerUtils {
                 .withEnv("ALLOW_EMPTY_PASSWORD", "yes")
                 .withEnv("REDIS_CLUSTER_CREATOR", "yes")
                 .withEnv("REDIS_NODES", range(0, TOTAL_NODES - 1).mapToObj(RedisClusterContainerUtils::getRegularNodeName).collect(joining(",")))
-                .waitingFor(Wait.forLogMessage(".*Cluster correctly created.*\\n", 1));
+                .withEnv("REDIS_DISABLE_COMMANDS", "KEYS")
+                .waitingFor(Wait.forLogMessage(".*Cluster correctly created*\\n", 1));
         }
         return new GenericContainer<>(REDIS_CLUSTER_DOCKER_NAME)
             .withExposedPorts(REDIS_PORT)
@@ -78,6 +79,7 @@ public final class RedisClusterContainerUtils {
             .withEnv("ALLOW_EMPTY_PASSWORD", "yes")
             .withEnv("REDIS_CLUSTER_CREATOR", "no")
             .withEnv("REDIS_NODES", CREATOR_NODE_NAME)
+            .withEnv("REDIS_DISABLE_COMMANDS", "KEYS")
             .waitingFor(Wait.forLogMessage(".*Setting Redis config file.*\\n", 1));
     }
 

--- a/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisContainerUtils.java
+++ b/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisContainerUtils.java
@@ -27,6 +27,12 @@ public final class RedisContainerUtils {
                 .withExposedPorts(REDIS_PORT)
                 .waitingFor(
                     Wait.forLogMessage(".*Ready to accept connections.*\\n", 1)
+                )
+                .withCommand(
+                    "redis-server",
+                    "--rename-command",
+                    "KEYS",
+                    ""
                 );
             redisContainer.start();
         }

--- a/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisReplicaContainerUtils.java
+++ b/redis-lettuce/src/test/java/io/micronaut/redis/test/RedisReplicaContainerUtils.java
@@ -45,6 +45,12 @@ public final class RedisReplicaContainerUtils {
                 .withExposedPorts(REDIS_PORT)
                 .withNetwork(SHARED)
                 .withNetworkAliases(PRIMARY_NODE_NAME)
+                .withCommand(
+                    "redis-server",
+                    "--rename-command",
+                    "KEYS",
+                    ""
+                )
                 .waitingFor(Wait.forListeningPort());
             primaryContainer.start();
         }
@@ -58,7 +64,10 @@ public final class RedisReplicaContainerUtils {
                     "redis-server",
                     "--slaveof",
                     PRIMARY_NODE_NAME,
-                    String.valueOf(REDIS_PORT)
+                    String.valueOf(REDIS_PORT),
+                    "--rename-command",
+                    "KEYS",
+                    ""
                 )
                 .waitingFor(Wait.forListeningPort());
             replicaContainer.start();


### PR DESCRIPTION
Implements the improvement described in #543

Summary - the KEYS command is not recommended for production use and is disabled in AWS Serverless Elasticache environments. Instead of using the KEYS command use a SCAN command to find all of the keys matching the desired pattern.