### PR TITLE
Added how to disable the lettuce health indicator if needed

### DIFF
--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -81,7 +81,8 @@ include::{testsredis}/NamedCodecFactory.groovy[tags=namedCodec2, indent=0]
 When the `redis-lettuce` module is activated a api:configuration.lettuce.health.RedisHealthIndicator[] is activated resulting in the `/health` endpoint and https://docs.micronaut.io/latest/api/io/micronaut/health/CurrentHealthStatus.html[CurrentHealthStatus] interface resolving the health of the Redis connection or connections.
 
 The health indicator is enabled by default. To disable the health endpoint, you can do so via the config. 
-```redis:
+```
+redis:
    health:
     enabled: false
 ```

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -80,6 +80,12 @@ include::{testsredis}/NamedCodecFactory.groovy[tags=namedCodec2, indent=0]
 
 When the `redis-lettuce` module is activated a api:configuration.lettuce.health.RedisHealthIndicator[] is activated resulting in the `/health` endpoint and https://docs.micronaut.io/latest/api/io/micronaut/health/CurrentHealthStatus.html[CurrentHealthStatus] interface resolving the health of the Redis connection or connections.
 
+The health indicator is enabled by default. To disable the health endpoint, you can do so via the config. 
+`redis:
+   health:
+    enabled: false
+`
+
 See the section on the https://docs.micronaut.io/latest/guide/index.html#healthEndpoint[Health Endpoint] for more information.
 
 == Disabling Redis

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -81,10 +81,10 @@ include::{testsredis}/NamedCodecFactory.groovy[tags=namedCodec2, indent=0]
 When the `redis-lettuce` module is activated a api:configuration.lettuce.health.RedisHealthIndicator[] is activated resulting in the `/health` endpoint and https://docs.micronaut.io/latest/api/io/micronaut/health/CurrentHealthStatus.html[CurrentHealthStatus] interface resolving the health of the Redis connection or connections.
 
 The health indicator is enabled by default. To disable the health endpoint, you can do so via the config. 
-`redis:
+```redis:
    health:
     enabled: false
-`
+```
 
 See the section on the https://docs.micronaut.io/latest/guide/index.html#healthEndpoint[Health Endpoint] for more information.
 

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -81,11 +81,12 @@ include::{testsredis}/NamedCodecFactory.groovy[tags=namedCodec2, indent=0]
 When the `redis-lettuce` module is activated a api:configuration.lettuce.health.RedisHealthIndicator[] is activated resulting in the `/health` endpoint and https://docs.micronaut.io/latest/api/io/micronaut/health/CurrentHealthStatus.html[CurrentHealthStatus] interface resolving the health of the Redis connection or connections.
 
 The health indicator is enabled by default. To disable the health endpoint, you can do so via the config. 
-```
+[configuration]
+----
 redis:
    health:
     enabled: false
-```
+----
 
 See the section on the https://docs.micronaut.io/latest/guide/index.html#healthEndpoint[Health Endpoint] for more information.
 


### PR DESCRIPTION
This adds information about how to disable the micronaut lettuce health indicator if needed. It is not very obvious how to do it, except by looking at the code.