### PR TITLE
Fix `java.lang.IllegalArgumentException: Keys must not be empty` during async invalidateAll if the cache is empty

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -272,8 +272,12 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
         public CompletableFuture<Boolean> invalidateAll() {
             ScanArgs args = ScanArgs.Builder.limit(invalidateScanCount).match(getKeysPattern().getBytes(redisCacheConfiguration.getCharset()));
 
-            return allKeys(ScanCursor.INITIAL, args).thenCompose(keysToDelete ->
-                deleteByKeys(keysToDelete.toArray(new byte[keysToDelete.size()][]))
+            return allKeys(ScanCursor.INITIAL, args).thenCompose(keysToDelete -> {
+                    if (keysToDelete.isEmpty()) {
+                        return CompletableFuture.completedFuture(false);
+                    }
+                    return deleteByKeys(keysToDelete.toArray(new byte[keysToDelete.size()][]));
+                }
             );
         }
 

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
@@ -178,6 +178,21 @@ class RedisCacheSpec extends RedisSpec {
         applicationContext.stop()
     }
 
+    void "test invalidateAll with redis sync cache that is already empty"() {
+        setup:
+        ApplicationContext applicationContext = createApplicationContext()
+
+        when:
+        RedisCache redisCache = applicationContext.getBean(RedisCache, Qualifiers.byName("test"))
+        redisCache.invalidateAll()
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        applicationContext.stop()
+    }
+
     void "test invalidateAll with redis sync cache"() {
         setup:
         ApplicationContext applicationContext = createApplicationContext()
@@ -208,6 +223,21 @@ class RedisCacheSpec extends RedisSpec {
         for( var i = 0; i < 100; i++) {
             !redisCache.get(i.toString(), Foo).isPresent()
         }
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    void "test invalidateAll with redis async cache that is already empty"() {
+        setup:
+        ApplicationContext applicationContext = createApplicationContext()
+
+        when:
+        RedisCache redisCache = applicationContext.getBean(RedisCache, Qualifiers.byName("test"))
+        redisCache.async().invalidateAll().join()
+
+        then:
+        noExceptionThrown()
 
         cleanup:
         applicationContext.stop()


### PR DESCRIPTION
Synchronous invalidateAll() has this check already, but the async one does not