### PR TITLE
Fix cluster codec test coverage

### DIFF
--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactoryCodecSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactoryCodecSpec.groovy
@@ -1,0 +1,116 @@
+package io.micronaut.configuration.lettuce
+
+import io.lettuce.core.codec.ByteArrayCodec
+import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.cluster.RedisClusterClient
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
+
+class DefaultRedisClusterClientFactoryCodecSpec extends Specification {
+
+    void cleanup() {
+        TestRedisClusterClient.reset()
+    }
+
+    void "test defined codec is passed to the cluster client"() {
+        when:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'redis.uris': ['redis://localhost:6379'],
+                'spec.name': TestRedisClusterClientFactory.SPEC_NAME,
+        )
+        applicationContext.getBean(StatefulRedisClusterConnection)
+
+        then:
+        TestRedisClusterClient.lastCodec == ByteArrayCodec.INSTANCE
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class TestRedisClusterClientFactory {
+        static final String SPEC_NAME = "cluster-byte-array-codec"
+
+        @Singleton
+        @Replaces(RedisCodec)
+        RedisCodec<byte[], byte[]> redisCodec() {
+            return ByteArrayCodec.INSTANCE
+        }
+
+        @Singleton
+        @Primary
+        @Replaces(RedisClusterClient)
+        RedisClusterClient redisClusterClient() {
+            return new TestRedisClusterClient()
+        }
+    }
+
+    static final class TestRedisClusterClient extends RedisClusterClient {
+        static RedisCodec<?, ?> lastCodec
+
+        @Override
+        <K, V> StatefulRedisClusterConnection<K, V> connect(RedisCodec<K, V> codec) {
+            lastCodec = codec
+            return (StatefulRedisClusterConnection<K, V>) Proxy.newProxyInstance(
+                    StatefulRedisClusterConnection.class.classLoader,
+                    [StatefulRedisClusterConnection] as Class[],
+                    new DefaultInvocationHandler()
+            )
+        }
+
+        static void reset() {
+            lastCodec = null
+        }
+    }
+
+    static final class DefaultInvocationHandler implements InvocationHandler {
+        @Override
+        Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+            if (method.name == "equals") {
+                return proxy.is(args[0])
+            }
+            if (method.name == "hashCode") {
+                return System.identityHashCode(proxy)
+            }
+            if (method.name == "toString") {
+                return "TestStatefulRedisClusterConnection"
+            }
+            Class<?> returnType = method.returnType
+            if (returnType == Boolean.TYPE) {
+                return false
+            }
+            if (returnType == Byte.TYPE) {
+                return (byte) 0
+            }
+            if (returnType == Short.TYPE) {
+                return (short) 0
+            }
+            if (returnType == Integer.TYPE) {
+                return 0
+            }
+            if (returnType == Long.TYPE) {
+                return 0L
+            }
+            if (returnType == Float.TYPE) {
+                return 0F
+            }
+            if (returnType == Double.TYPE) {
+                return 0D
+            }
+            if (returnType == Character.TYPE) {
+                return (char) 0
+            }
+            return null
+        }
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/DefaultRedisClusterClientFactorySpec.groovy
@@ -10,7 +10,6 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.core.type.Argument
-import spock.lang.Ignore
 
 class DefaultRedisClusterClientFactorySpec extends RedisClusterSpec {
 
@@ -127,13 +126,14 @@ class DefaultRedisClusterClientFactorySpec extends RedisClusterSpec {
         thrown(ConfigurationException)
     }
 
-    @Ignore
     void "test redis client uses defined codec"() {
         when:
         ApplicationContext applicationContext = ApplicationContext.run(
                 'redis.uris': redisClusterUris,
                 'spec.name': ByteArrayCodecReplacementFactory.SPEC_NAME,
         )
+        RedisClusterClient client = applicationContext.getBean(RedisClusterClient)
+        fixPartitions(client)
         StatefulRedisClusterConnection connection = applicationContext.getBean(StatefulRedisClusterConnection)
 
         then:


### PR DESCRIPTION
Summary:
- remove the stale ignore from the cluster codec integration test
- fix cluster partitions before opening the connection in that test
- add a focused unit-style regression test that verifies the configured codec is passed to the cluster client

Verification:
- ./gradlew :micronaut-redis-lettuce:test --tests "*DefaultRedisClusterClientFactoryCodecSpec"
- ./gradlew :micronaut-redis-lettuce:test --tests "*DefaultRedisClusterClientFactorySpec.test redis client uses defined codec" --test-dry-run
- ./gradlew :micronaut-redis-lettuce:spotlessCheck

Resolves #655