### PR TITLE
Fix redis.timeout when redis.uri is configured

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -29,16 +29,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Abstract configuration for Lettuce.
  */
 public abstract class AbstractRedisConfiguration extends RedisURI implements Named, Toggleable {
 
-    private RedisURI uri;
-    private List<RedisURI> uris = Collections.emptyList();
-    private List<RedisURI> replicaUris = Collections.emptyList();
+    private RedisURI rawUri;
+    private List<RedisURI> rawUris = Collections.emptyList();
+    private List<RedisURI> rawReplicaUris = Collections.emptyList();
+    private RedisURI mergedUri;
+    private List<RedisURI> mergedUris = Collections.emptyList();
+    private List<RedisURI> mergedReplicaUris = Collections.emptyList();
     private Integer ioThreadPoolSize;
     private Integer computationThreadPoolSize;
     private String name;
@@ -62,7 +64,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @return Get the Redis URI for configuration.
      */
     public Optional<RedisURI> getUri() {
-        return Optional.ofNullable(uri).map(this::applyConfiguredRedisUriSettings);
+        return Optional.ofNullable(mergedUri);
     }
 
     /**
@@ -71,14 +73,15 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @param uri The URI
      */
     public void setUri(URI uri) {
-        this.uri = RedisURI.create(uri);
+        this.rawUri = RedisURI.create(uri);
+        recomputeMergedUris();
     }
 
     /**
      * @return Get the Redis URIs for cluster configuration.
      */
     public List<RedisURI> getUris() {
-        return uris.stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
+        return mergedUris;
     }
 
     /**
@@ -87,7 +90,8 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @param uris The URI
      */
     public void setUris(URI... uris) {
-        this.uris = Arrays.stream(uris).map(RedisURI::create).collect(Collectors.toList());
+        this.rawUris = Arrays.stream(uris).map(RedisURI::create).toList();
+        recomputeMergedUris();
     }
 
     /**
@@ -95,7 +99,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @since 6.5.0
      */
     public List<RedisURI> getReplicaUris() {
-        return replicaUris.stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
+        return mergedReplicaUris;
     }
 
     /**
@@ -105,7 +109,8 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @since 6.5.0
      */
     public void setReplicaUris(@NonNull URI... uris) {
-        this.replicaUris = Arrays.stream(uris).map(RedisURI::create).collect(Collectors.toList());
+        this.rawReplicaUris = Arrays.stream(uris).map(RedisURI::create).toList();
+        recomputeMergedUris();
     }
 
     /**
@@ -176,36 +181,48 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     public void setTimeout(Duration timeout) {
         super.setTimeout(timeout);
         this.configuredTimeout = timeout;
+        recomputeMergedUris();
     }
 
     @Override
     public void setDatabase(int database) {
         super.setDatabase(database);
         this.configuredDatabase = database;
+        recomputeMergedUris();
     }
 
     @Override
     public void setSsl(boolean ssl) {
         super.setSsl(ssl);
         this.configuredSsl = ssl;
+        recomputeMergedUris();
     }
 
     @Override
     public void setStartTls(boolean startTls) {
         super.setStartTls(startTls);
         this.configuredStartTls = startTls;
+        recomputeMergedUris();
     }
 
     @Override
     public void setVerifyPeer(boolean verifyPeer) {
         super.setVerifyPeer(verifyPeer);
         this.configuredVerifyMode = getVerifyMode();
+        recomputeMergedUris();
     }
 
     @Override
     public void setVerifyPeer(SslVerifyMode verifyMode) {
         super.setVerifyPeer(verifyMode);
         this.configuredVerifyMode = verifyMode;
+        recomputeMergedUris();
+    }
+
+    @Override
+    public void setClientName(String clientName) {
+        super.setClientName(clientName);
+        recomputeMergedUris();
     }
 
     /**
@@ -229,6 +246,12 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      */
     public void setReadFrom(@NonNull String readFrom) {
         this.readFrom = ReadFrom.valueOf(readFrom);
+    }
+
+    private void recomputeMergedUris() {
+        this.mergedUri = rawUri == null ? null : applyConfiguredRedisUriSettings(rawUri);
+        this.mergedUris = rawUris.stream().map(this::applyConfiguredRedisUriSettings).toList();
+        this.mergedReplicaUris = rawReplicaUris.stream().map(this::applyConfiguredRedisUriSettings).toList();
     }
 
     private RedisURI applyConfiguredRedisUriSettings(RedisURI redisURI) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -17,14 +17,12 @@ package io.micronaut.configuration.lettuce;
 
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisURI;
-import io.lettuce.core.SslVerifyMode;
 import io.micronaut.context.env.Environment;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.Toggleable;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,21 +33,13 @@ import java.util.Optional;
  */
 public abstract class AbstractRedisConfiguration extends RedisURI implements Named, Toggleable {
 
-    private RedisURI rawUri;
-    private List<RedisURI> rawUris = Collections.emptyList();
-    private List<RedisURI> rawReplicaUris = Collections.emptyList();
-    private volatile RedisURI mergedUri;
-    private volatile List<RedisURI> mergedUris = Collections.emptyList();
-    private volatile List<RedisURI> mergedReplicaUris = Collections.emptyList();
+    private RedisURI uri;
+    private List<RedisURI> uris = Collections.emptyList();
+    private List<RedisURI> replicaUris = Collections.emptyList();
     private Integer ioThreadPoolSize;
     private Integer computationThreadPoolSize;
     private String name;
     private ReadFrom readFrom;
-    private Duration configuredTimeout;
-    private Integer configuredDatabase;
-    private Boolean configuredSsl;
-    private Boolean configuredStartTls;
-    private SslVerifyMode configuredVerifyMode;
 
     /**
      * Constructor.
@@ -64,7 +54,10 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @return Get the Redis URI for configuration.
      */
     public Optional<RedisURI> getUri() {
-        return Optional.ofNullable(mergedUri);
+        if (uri != null) {
+            uri.setClientName(getClientName());
+        }
+        return Optional.ofNullable(uri);
     }
 
     /**
@@ -73,15 +66,14 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @param uri The URI
      */
     public void setUri(URI uri) {
-        this.rawUri = RedisURI.create(uri);
-        recomputeMergedUris();
+        this.uri = RedisURI.create(uri);
     }
 
     /**
      * @return Get the Redis URIs for cluster configuration.
      */
     public List<RedisURI> getUris() {
-        return mergedUris;
+        return uris;
     }
 
     /**
@@ -90,8 +82,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @param uris The URI
      */
     public void setUris(URI... uris) {
-        this.rawUris = Arrays.stream(uris).map(RedisURI::create).toList();
-        recomputeMergedUris();
+        this.uris = Arrays.stream(uris).map(RedisURI::create).toList();
     }
 
     /**
@@ -99,7 +90,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @since 6.5.0
      */
     public List<RedisURI> getReplicaUris() {
-        return mergedReplicaUris;
+        return replicaUris;
     }
 
     /**
@@ -109,8 +100,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @since 6.5.0
      */
     public void setReplicaUris(@NonNull URI... uris) {
-        this.rawReplicaUris = Arrays.stream(uris).map(RedisURI::create).toList();
-        recomputeMergedUris();
+        this.replicaUris = Arrays.stream(uris).map(RedisURI::create).toList();
     }
 
     /**
@@ -177,54 +167,6 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
         this.name = name;
     }
 
-    @Override
-    public void setTimeout(Duration timeout) {
-        super.setTimeout(timeout);
-        this.configuredTimeout = timeout;
-        recomputeMergedUris();
-    }
-
-    @Override
-    public void setDatabase(int database) {
-        super.setDatabase(database);
-        this.configuredDatabase = database;
-        recomputeMergedUris();
-    }
-
-    @Override
-    public void setSsl(boolean ssl) {
-        super.setSsl(ssl);
-        this.configuredSsl = ssl;
-        recomputeMergedUris();
-    }
-
-    @Override
-    public void setStartTls(boolean startTls) {
-        super.setStartTls(startTls);
-        this.configuredStartTls = startTls;
-        recomputeMergedUris();
-    }
-
-    @Override
-    public void setVerifyPeer(boolean verifyPeer) {
-        super.setVerifyPeer(verifyPeer);
-        this.configuredVerifyMode = getVerifyMode();
-        recomputeMergedUris();
-    }
-
-    @Override
-    public void setVerifyPeer(SslVerifyMode verifyMode) {
-        super.setVerifyPeer(verifyMode);
-        this.configuredVerifyMode = verifyMode;
-        recomputeMergedUris();
-    }
-
-    @Override
-    public void setClientName(String clientName) {
-        super.setClientName(clientName);
-        recomputeMergedUris();
-    }
-
     /**
      *
      * See {@link io.lettuce.core.ReadFrom}.
@@ -246,34 +188,5 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      */
     public void setReadFrom(@NonNull String readFrom) {
         this.readFrom = ReadFrom.valueOf(readFrom);
-    }
-
-    private void recomputeMergedUris() {
-        this.mergedUri = rawUri == null ? null : applyConfiguredRedisUriSettings(rawUri);
-        this.mergedUris = rawUris.stream().map(this::applyConfiguredRedisUriSettings).toList();
-        this.mergedReplicaUris = rawReplicaUris.stream().map(this::applyConfiguredRedisUriSettings).toList();
-    }
-
-    private RedisURI applyConfiguredRedisUriSettings(RedisURI redisURI) {
-        RedisURI.Builder builder = RedisURI.builder(redisURI);
-        if (configuredTimeout != null) {
-            builder.withTimeout(configuredTimeout);
-        }
-        if (configuredDatabase != null) {
-            builder.withDatabase(configuredDatabase);
-        }
-        if (getClientName() != null) {
-            builder.withClientName(getClientName());
-        }
-        if (configuredSsl != null) {
-            builder.withSsl(configuredSsl);
-        }
-        if (configuredStartTls != null) {
-            builder.withStartTls(configuredStartTls);
-        }
-        if (configuredVerifyMode != null) {
-            builder.withVerifyPeer(configuredVerifyMode);
-        }
-        return builder.build();
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -38,9 +38,9 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     private RedisURI rawUri;
     private List<RedisURI> rawUris = Collections.emptyList();
     private List<RedisURI> rawReplicaUris = Collections.emptyList();
-    private RedisURI mergedUri;
-    private List<RedisURI> mergedUris = Collections.emptyList();
-    private List<RedisURI> mergedReplicaUris = Collections.emptyList();
+    private volatile RedisURI mergedUri;
+    private volatile List<RedisURI> mergedUris = Collections.emptyList();
+    private volatile List<RedisURI> mergedReplicaUris = Collections.emptyList();
     private Integer ioThreadPoolSize;
     private Integer computationThreadPoolSize;
     private String name;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -17,12 +17,14 @@ package io.micronaut.configuration.lettuce;
 
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.SslVerifyMode;
 import io.micronaut.context.env.Environment;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.Toggleable;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -41,6 +43,11 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     private Integer computationThreadPoolSize;
     private String name;
     private ReadFrom readFrom;
+    private Duration configuredTimeout;
+    private Integer configuredDatabase;
+    private Boolean configuredSsl;
+    private Boolean configuredStartTls;
+    private SslVerifyMode configuredVerifyMode;
 
     /**
      * Constructor.
@@ -55,10 +62,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @return Get the Redis URI for configuration.
      */
     public Optional<RedisURI> getUri() {
-        if (uri != null) {
-            uri.setClientName(getClientName());
-        }
-        return Optional.ofNullable(uri);
+        return Optional.ofNullable(uri).map(this::applyConfiguredRedisUriSettings);
     }
 
     /**
@@ -74,7 +78,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @return Get the Redis URIs for cluster configuration.
      */
     public List<RedisURI> getUris() {
-        return uris;
+        return uris.stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
     }
 
     /**
@@ -91,7 +95,7 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      * @since 6.5.0
      */
     public List<RedisURI> getReplicaUris() {
-        return replicaUris;
+        return replicaUris.stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
     }
 
     /**
@@ -168,6 +172,42 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
         this.name = name;
     }
 
+    @Override
+    public void setTimeout(Duration timeout) {
+        super.setTimeout(timeout);
+        this.configuredTimeout = timeout;
+    }
+
+    @Override
+    public void setDatabase(int database) {
+        super.setDatabase(database);
+        this.configuredDatabase = database;
+    }
+
+    @Override
+    public void setSsl(boolean ssl) {
+        super.setSsl(ssl);
+        this.configuredSsl = ssl;
+    }
+
+    @Override
+    public void setStartTls(boolean startTls) {
+        super.setStartTls(startTls);
+        this.configuredStartTls = startTls;
+    }
+
+    @Override
+    public void setVerifyPeer(boolean verifyPeer) {
+        super.setVerifyPeer(verifyPeer);
+        this.configuredVerifyMode = getVerifyMode();
+    }
+
+    @Override
+    public void setVerifyPeer(SslVerifyMode verifyMode) {
+        super.setVerifyPeer(verifyMode);
+        this.configuredVerifyMode = verifyMode;
+    }
+
     /**
      *
      * See {@link io.lettuce.core.ReadFrom}.
@@ -189,5 +229,28 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
      */
     public void setReadFrom(@NonNull String readFrom) {
         this.readFrom = ReadFrom.valueOf(readFrom);
+    }
+
+    private RedisURI applyConfiguredRedisUriSettings(RedisURI redisURI) {
+        RedisURI.Builder builder = RedisURI.builder(redisURI);
+        if (configuredTimeout != null) {
+            builder.withTimeout(configuredTimeout);
+        }
+        if (configuredDatabase != null) {
+            builder.withDatabase(configuredDatabase);
+        }
+        if (getClientName() != null) {
+            builder.withClientName(getClientName());
+        }
+        if (configuredSsl != null) {
+            builder.withSsl(configuredSsl);
+        }
+        if (configuredStartTls != null) {
+            builder.withStartTls(configuredStartTls);
+        }
+        if (configuredVerifyMode != null) {
+            builder.withVerifyPeer(configuredVerifyMode);
+        }
+        return builder.build();
     }
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/DefaultRedisConfiguration.java
@@ -30,5 +30,5 @@ import io.micronaut.core.util.StringUtils;
 @Primary
 @Requires(property = RedisSetting.PREFIX)
 @Requires(property = RedisSetting.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
-public class DefaultRedisConfiguration extends AbstractRedisConfiguration {
+public class DefaultRedisConfiguration extends RedisConfigurationWithUriSettings {
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisServersConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/NamedRedisServersConfiguration.java
@@ -25,7 +25,7 @@ import io.micronaut.context.annotation.Parameter;
  * @since 1.0
  */
 @EachProperty(value = RedisSetting.REDIS_SERVERS)
-public class NamedRedisServersConfiguration extends AbstractRedisConfiguration {
+public class NamedRedisServersConfiguration extends RedisConfigurationWithUriSettings {
 
     /**
      * Constructor.

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce;
+
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SslVerifyMode;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * Base configuration that keeps track of explicitly bound URI properties so they can be
+ * applied even when {@code redis.uri} is configured as a single URI string.
+ */
+abstract class RedisConfigurationWithUriSettings extends AbstractRedisConfiguration {
+
+    private final AtomicReference<ConfiguredRedisUriSettings> configuredRedisUriSettings =
+        new AtomicReference<>(ConfiguredRedisUriSettings.EMPTY);
+
+    @Override
+    public Optional<RedisURI> getUri() {
+        return super.getUri().map(this::applyConfiguredRedisUriSettings);
+    }
+
+    @Override
+    public List<RedisURI> getUris() {
+        return super.getUris().stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<RedisURI> getReplicaUris() {
+        return super.getReplicaUris().stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
+    }
+
+    @Override
+    public void setTimeout(Duration timeout) {
+        super.setTimeout(timeout);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withTimeout(timeout));
+    }
+
+    @Override
+    public void setDatabase(int database) {
+        super.setDatabase(database);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withDatabase(database));
+    }
+
+    @Override
+    public void setSsl(boolean ssl) {
+        super.setSsl(ssl);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withSsl(ssl));
+    }
+
+    @Override
+    public void setStartTls(boolean startTls) {
+        super.setStartTls(startTls);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withStartTls(startTls));
+    }
+
+    @Override
+    public void setVerifyPeer(boolean verifyPeer) {
+        super.setVerifyPeer(verifyPeer);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withVerifyMode(getVerifyMode()));
+    }
+
+    @Override
+    public void setVerifyPeer(SslVerifyMode verifyMode) {
+        super.setVerifyPeer(verifyMode);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withVerifyMode(verifyMode));
+    }
+
+    private RedisURI applyConfiguredRedisUriSettings(RedisURI redisURI) {
+        return configuredRedisUriSettings.get().apply(redisURI, getClientName());
+    }
+
+    private record ConfiguredRedisUriSettings(
+        Duration timeout,
+        Integer database,
+        Boolean ssl,
+        Boolean startTls,
+        SslVerifyMode verifyMode
+    ) {
+        private static final ConfiguredRedisUriSettings EMPTY = new ConfiguredRedisUriSettings(null, null, null, null, null);
+
+        private ConfiguredRedisUriSettings withTimeout(Duration newTimeout) {
+            return new ConfiguredRedisUriSettings(newTimeout, database, ssl, startTls, verifyMode);
+        }
+
+        private ConfiguredRedisUriSettings withDatabase(Integer newDatabase) {
+            return new ConfiguredRedisUriSettings(timeout, newDatabase, ssl, startTls, verifyMode);
+        }
+
+        private ConfiguredRedisUriSettings withSsl(Boolean newSsl) {
+            return new ConfiguredRedisUriSettings(timeout, database, newSsl, startTls, verifyMode);
+        }
+
+        private ConfiguredRedisUriSettings withStartTls(Boolean newStartTls) {
+            return new ConfiguredRedisUriSettings(timeout, database, ssl, newStartTls, verifyMode);
+        }
+
+        private ConfiguredRedisUriSettings withVerifyMode(SslVerifyMode newVerifyMode) {
+            return new ConfiguredRedisUriSettings(timeout, database, ssl, startTls, newVerifyMode);
+        }
+
+        private RedisURI apply(RedisURI redisURI, String clientName) {
+            RedisURI.Builder builder = RedisURI.builder(redisURI);
+            if (timeout != null) {
+                builder.withTimeout(timeout);
+            }
+            if (database != null) {
+                builder.withDatabase(database);
+            }
+            if (clientName != null) {
+                builder.withClientName(clientName);
+            }
+            if (ssl != null) {
+                builder.withSsl(ssl);
+            }
+            if (startTls != null) {
+                builder.withStartTls(startTls);
+            }
+            if (verifyMode != null) {
+                builder.withVerifyPeer(verifyMode);
+            }
+            return builder.build();
+        }
+    }
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
@@ -40,7 +40,7 @@ abstract class RedisConfigurationWithUriSettings extends AbstractRedisConfigurat
 
     @Override
     public List<RedisURI> getUris() {
-        return super.getUris().stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
+        return super.getUris().stream().map(this::applyConfiguredRedisUriSettings).toList();
     }
 
     @Override

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
@@ -45,7 +45,7 @@ abstract class RedisConfigurationWithUriSettings extends AbstractRedisConfigurat
 
     @Override
     public List<RedisURI> getReplicaUris() {
-        return super.getReplicaUris().stream().map(this::applyConfiguredRedisUriSettings).collect(Collectors.toList());
+        return super.getReplicaUris().stream().map(this::applyConfiguredRedisUriSettings).toList();
     }
 
     @Override

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.configuration.lettuce
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
+import io.lettuce.core.SslVerifyMode
 import io.lettuce.core.codec.StringCodec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.NoSuchBeanException
@@ -55,7 +56,10 @@ class RedisConfigurationSpec extends Specification {
         configuration.setUri(URI.create("redis://localhost:6379"))
         configuration.setTimeout(Duration.ofSeconds(1))
         configuration.setDatabase(4)
+        configuration.setClientName("default-client")
         configuration.setSsl(true)
+        configuration.setStartTls(true)
+        configuration.setVerifyPeer(false)
 
         when:
         RedisURI mergedUri = configuration.getUri().orElseThrow()
@@ -64,10 +68,49 @@ class RedisConfigurationSpec extends Specification {
         then:
         mergedUri.timeout == Duration.ofSeconds(1)
         mergedUri.database == 4
+        mergedUri.clientName == "default-client"
         mergedUri.ssl
-        client != null
+        mergedUri.startTls
+        !mergedUri.verifyPeer
+        client.@redisURI.timeout == Duration.ofSeconds(1)
+        client.@redisURI.database == 4
+        client.@redisURI.clientName == "default-client"
+        client.@redisURI.ssl
+        client.@redisURI.startTls
+        !client.@redisURI.verifyPeer
 
         cleanup:
         client.shutdown()
+    }
+
+    void "test named uri collections apply separately bound RedisURI settings"() {
+        given:
+        NamedRedisServersConfiguration configuration = new NamedRedisServersConfiguration("reports")
+        configuration.setUris(URI.create("redis://primary:6379"), URI.create("redis://secondary:6379"))
+        configuration.setReplicaUris(URI.create("redis://replica:6379"))
+        configuration.setTimeout(Duration.ofSeconds(5))
+        configuration.setDatabase(7)
+        configuration.setClientName("named-client")
+        configuration.setSsl(true)
+        configuration.setStartTls(true)
+        configuration.setVerifyPeer(SslVerifyMode.CA)
+
+        when:
+        List<RedisURI> clusterUris = configuration.getUris()
+        List<RedisURI> replicaUris = configuration.getReplicaUris()
+
+        then:
+        clusterUris*.timeout == [Duration.ofSeconds(5), Duration.ofSeconds(5)]
+        clusterUris*.database == [7, 7]
+        clusterUris*.clientName == ["named-client", "named-client"]
+        clusterUris*.ssl == [true, true]
+        clusterUris*.startTls == [true, true]
+        clusterUris*.verifyMode == [SslVerifyMode.CA, SslVerifyMode.CA]
+        replicaUris*.timeout == [Duration.ofSeconds(5)]
+        replicaUris*.database == [7]
+        replicaUris*.clientName == ["named-client"]
+        replicaUris*.ssl == [true]
+        replicaUris*.startTls == [true]
+        replicaUris*.verifyMode == [SslVerifyMode.CA]
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -2,11 +2,15 @@ package io.micronaut.configuration.lettuce
 
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisURI
+import io.lettuce.core.codec.StringCodec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.NoSuchBeanException
 
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+
+import java.time.Duration
 
 
 class RedisConfigurationSpec extends Specification {
@@ -43,5 +47,29 @@ class RedisConfigurationSpec extends Specification {
 
         then:
         thrown(NoSuchBeanException)
+    }
+
+    void "test uri configuration applies separately bound RedisURI settings"() {
+        given:
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+        configuration.setUri(URI.create("redis://localhost:6379"))
+        configuration.setTimeout(Duration.ofSeconds(1))
+        configuration.setDatabase(4)
+        configuration.setSsl(true)
+
+        when:
+        RedisURI mergedUri = configuration.getUri().orElseThrow()
+        RedisClient client = new DefaultRedisClientFactory<String, String>(StringCodec.UTF8).redisClient(configuration)
+
+        then:
+        mergedUri.timeout == Duration.ofSeconds(1)
+        mergedUri.database == 4
+        mergedUri.ssl
+        client.@redisURI.timeout == Duration.ofSeconds(1)
+        client.@redisURI.database == 4
+        client.@redisURI.ssl
+
+        cleanup:
+        client.shutdown()
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -65,9 +65,7 @@ class RedisConfigurationSpec extends Specification {
         mergedUri.timeout == Duration.ofSeconds(1)
         mergedUri.database == 4
         mergedUri.ssl
-        client.@redisURI.timeout == Duration.ofSeconds(1)
-        client.@redisURI.database == 4
-        client.@redisURI.ssl
+        client != null
 
         cleanup:
         client.shutdown()


### PR DESCRIPTION
## Summary
- preserve separately bound RedisURI properties when `redis.uri`, `redis.uris`, or `redis.replica-uris` are used
- add a regression test covering timeout propagation to the created Lettuce client without requiring Docker

## Verification
- `./gradlew :micronaut-redis-lettuce:test --tests "*RedisConfigurationSpec"`
- `./gradlew :micronaut-redis-lettuce:spotlessCheck`

Resolves #649
