### PR TITLE
Add pooled Lettuce connections for parallel reactive work

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
@@ -48,7 +48,7 @@ import java.util.concurrent.CompletionStage;
  */
 @Factory
 @Requires(beans = {DefaultRedisConfiguration.class, DefaultRedisConnectionPoolConfiguration.class})
-public final class RedisConnectionPoolFactory<K, V> {
+public class RedisConnectionPoolFactory<K, V> {
 
     private final RedisCodec<K, V> defaultCodec;
 
@@ -117,19 +117,24 @@ public final class RedisConnectionPoolFactory<K, V> {
         return stage.toCompletableFuture().join();
     }
 
-    private StatefulRedisConnection<K, V> createConnection(RedisClient redisClient, AbstractRedisConfiguration config) {
-        if (config.getUri().isPresent() && !config.getReplicaUris().isEmpty()) {
+    StatefulRedisConnection<K, V> createConnection(RedisClient redisClient, AbstractRedisConfiguration config) {
+        RedisURI redisUri = config.getUri().orElse(null);
+        if (redisUri != null && !config.getReplicaUris().isEmpty()) {
             List<RedisURI> uris = new ArrayList<>(config.getReplicaUris());
-            uris.add(config.getUri().get());
+            uris.add(redisUri);
 
-            StatefulRedisMasterReplicaConnection<K, V> connection = MasterReplica.connect(redisClient, defaultCodec, uris);
+            StatefulRedisMasterReplicaConnection<K, V> connection = createMasterReplicaConnection(redisClient, uris);
             config.getReadFrom().ifPresent(connection::setReadFrom);
             return connection;
         }
         return redisClient.connect(defaultCodec);
     }
 
-    private StatefulRedisClusterConnection<K, V> createClusterConnection(
+    StatefulRedisMasterReplicaConnection<K, V> createMasterReplicaConnection(RedisClient redisClient, List<RedisURI> redisUris) {
+        return MasterReplica.connect(redisClient, defaultCodec, redisUris);
+    }
+
+    StatefulRedisClusterConnection<K, V> createClusterConnection(
         RedisClusterClient redisClient,
         AbstractRedisConfiguration config
     ) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
@@ -35,6 +35,7 @@ import jakarta.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -117,11 +118,20 @@ public class RedisConnectionPoolFactory<K, V> {
         return stage.toCompletableFuture().join();
     }
 
+    /**
+     * Creates a standalone or master-replica connection for the configured server definition.
+     * Subclasses overriding this method must keep the default codec and preserve the existing
+     * read-preference behavior for replica-aware connections.
+     *
+     * @param redisClient The Redis client
+     * @param config The Redis configuration
+     * @return The Redis connection
+     */
     StatefulRedisConnection<K, V> createConnection(RedisClient redisClient, AbstractRedisConfiguration config) {
-        RedisURI redisUri = config.getUri().orElse(null);
-        if (redisUri != null && !config.getReplicaUris().isEmpty()) {
+        Optional<RedisURI> redisUri = config.getUri();
+        if (redisUri.isPresent() && !config.getReplicaUris().isEmpty()) {
             List<RedisURI> uris = new ArrayList<>(config.getReplicaUris());
-            uris.add(redisUri);
+            uris.add(redisUri.orElseThrow());
 
             StatefulRedisMasterReplicaConnection<K, V> connection = createMasterReplicaConnection(redisClient, uris);
             config.getReadFrom().ifPresent(connection::setReadFrom);
@@ -130,10 +140,28 @@ public class RedisConnectionPoolFactory<K, V> {
         return redisClient.connect(defaultCodec);
     }
 
+    /**
+     * Creates the underlying master-replica connection used by {@link #createConnection(RedisClient, AbstractRedisConfiguration)}.
+     * Subclasses overriding this method must return an open connection backed by the supplied URIs
+     * and compatible with the factory's default codec.
+     *
+     * @param redisClient The Redis client
+     * @param redisUris The ordered Redis URIs, including the primary URI
+     * @return The master-replica connection
+     */
     StatefulRedisMasterReplicaConnection<K, V> createMasterReplicaConnection(RedisClient redisClient, List<RedisURI> redisUris) {
         return MasterReplica.connect(redisClient, defaultCodec, redisUris);
     }
 
+    /**
+     * Creates a cluster connection for the configured Redis client.
+     * Subclasses overriding this method must apply any configured read preference before returning
+     * the connection.
+     *
+     * @param redisClient The Redis cluster client
+     * @param config The Redis configuration
+     * @return The Redis cluster connection
+     */
     StatefulRedisClusterConnection<K, V> createClusterConnection(
         RedisClusterClient redisClient,
         AbstractRedisConfiguration config

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+import io.lettuce.core.support.AsyncConnectionPoolSupport;
+import io.lettuce.core.support.AsyncPool;
+import io.lettuce.core.support.BoundedAsyncPool;
+import io.lettuce.core.support.BoundedPoolConfig;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Creates optional pooled Redis connections for cases where callers need to run work across
+ * multiple underlying Lettuce connections instead of a single long-lived connection bean.
+ *
+ * @param <K> Key type
+ * @param <V> Value type
+ * @since 7.0.0
+ */
+@Factory
+@Requires(beans = {DefaultRedisConfiguration.class, DefaultRedisConnectionPoolConfiguration.class})
+public final class RedisConnectionPoolFactory<K, V> {
+
+    private final RedisCodec<K, V> defaultCodec;
+
+    /**
+     * @param defaultCodec The default codec
+     */
+    public RedisConnectionPoolFactory(@Primary RedisCodec<K, V> defaultCodec) {
+        this.defaultCodec = defaultCodec;
+    }
+
+    /**
+     * Creates a pool of default Redis connections.
+     *
+     * @param redisClient The Redis client
+     * @param config The Redis configuration
+     * @param poolConfiguration The pool configuration
+     * @return The connection pool
+     */
+    @Bean(preDestroy = "close")
+    @Singleton
+    @Primary
+    @Requires(beans = RedisClient.class)
+    @Requires(missingProperty = RedisSetting.REDIS_URIS)
+    public AsyncPool<StatefulRedisConnection<K, V>> redisConnectionPool(
+        @Primary RedisClient redisClient,
+        @Primary DefaultRedisConfiguration config,
+        DefaultRedisConnectionPoolConfiguration poolConfiguration
+    ) {
+        BoundedPoolConfig boundedPoolConfig = poolConfiguration.getBoundedPoolConfig();
+        CompletionStage<BoundedAsyncPool<StatefulRedisConnection<K, V>>> stage =
+            AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(
+                () -> CompletableFuture.completedFuture(createConnection(redisClient, config)),
+                boundedPoolConfig,
+                false
+            );
+        return stage.toCompletableFuture().join();
+    }
+
+    /**
+     * Creates a pool of default Redis cluster connections.
+     *
+     * @param redisClient The Redis cluster client
+     * @param config The Redis configuration
+     * @param poolConfiguration The pool configuration
+     * @return The connection pool
+     */
+    @Bean(preDestroy = "close")
+    @Singleton
+    @Primary
+    @Requires(beans = RedisClusterClient.class)
+    @Requires(property = RedisSetting.REDIS_URIS)
+    public AsyncPool<StatefulRedisClusterConnection<K, V>> redisClusterConnectionPool(
+        @Primary RedisClusterClient redisClient,
+        @Primary DefaultRedisConfiguration config,
+        DefaultRedisConnectionPoolConfiguration poolConfiguration
+    ) {
+        BoundedPoolConfig boundedPoolConfig = poolConfiguration.getBoundedPoolConfig();
+        CompletionStage<BoundedAsyncPool<StatefulRedisClusterConnection<K, V>>> stage =
+            AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(
+                () -> CompletableFuture.completedFuture(createClusterConnection(redisClient, config)),
+                boundedPoolConfig,
+                false
+            );
+        return stage.toCompletableFuture().join();
+    }
+
+    private StatefulRedisConnection<K, V> createConnection(RedisClient redisClient, AbstractRedisConfiguration config) {
+        if (config.getUri().isPresent() && !config.getReplicaUris().isEmpty()) {
+            List<RedisURI> uris = new ArrayList<>(config.getReplicaUris());
+            uris.add(config.getUri().get());
+
+            StatefulRedisMasterReplicaConnection<K, V> connection = MasterReplica.connect(redisClient, defaultCodec, uris);
+            config.getReadFrom().ifPresent(connection::setReadFrom);
+            return connection;
+        }
+        return redisClient.connect(defaultCodec);
+    }
+
+    private StatefulRedisClusterConnection<K, V> createClusterConnection(
+        RedisClusterClient redisClient,
+        AbstractRedisConfiguration config
+    ) {
+        StatefulRedisClusterConnection<K, V> connection = redisClient.connect(defaultCodec);
+        config.getReadFrom().ifPresent(connection::setReadFrom);
+        return connection;
+    }
+}

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionPoolFactory.java
@@ -78,9 +78,10 @@ public final class RedisConnectionPoolFactory<K, V> {
         DefaultRedisConnectionPoolConfiguration poolConfiguration
     ) {
         BoundedPoolConfig boundedPoolConfig = poolConfiguration.getBoundedPoolConfig();
+        // wrapConnections=false: callers must explicitly release connections via pool.release()
         CompletionStage<BoundedAsyncPool<StatefulRedisConnection<K, V>>> stage =
             AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(
-                () -> CompletableFuture.completedFuture(createConnection(redisClient, config)),
+                () -> CompletableFuture.supplyAsync(() -> createConnection(redisClient, config)),
                 boundedPoolConfig,
                 false
             );
@@ -106,9 +107,10 @@ public final class RedisConnectionPoolFactory<K, V> {
         DefaultRedisConnectionPoolConfiguration poolConfiguration
     ) {
         BoundedPoolConfig boundedPoolConfig = poolConfiguration.getBoundedPoolConfig();
+        // wrapConnections=false: callers must explicitly release connections via pool.release()
         CompletionStage<BoundedAsyncPool<StatefulRedisClusterConnection<K, V>>> stage =
             AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(
-                () -> CompletableFuture.completedFuture(createClusterConnection(redisClient, config)),
+                () -> CompletableFuture.supplyAsync(() -> createClusterConnection(redisClient, config)),
                 boundedPoolConfig,
                 false
             );

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisAsyncConnectionPoolFactory.java
@@ -35,6 +35,7 @@ import io.micronaut.context.BeanLocator;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.exceptions.ConfigurationException;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.util.ArrayList;
@@ -51,8 +52,10 @@ import java.util.concurrent.CompletionStage;
  */
 @Factory
 public final class RedisAsyncConnectionPoolFactory {
+    public static final String CACHE_POOL_BEAN = "redisCacheAsyncPool";
 
     @Singleton
+    @Named(CACHE_POOL_BEAN)
     @Requires(beans = {DefaultRedisCacheConfiguration.class, DefaultRedisConnectionPoolConfiguration.class, DefaultRedisConfiguration.class})
     public AsyncPool<StatefulConnection<byte[], byte[]>> getAsyncPool(
             DefaultRedisCacheConfiguration defaultRedisCacheConfiguration,

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
@@ -35,6 +35,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import jakarta.annotation.PreDestroy;
+import jakarta.inject.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +77,7 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
             RedisCacheConfiguration redisCacheConfiguration,
             ConversionService conversionService,
             BeanLocator beanLocator,
+            @Named(RedisAsyncConnectionPoolFactory.CACHE_POOL_BEAN)
             AsyncPool<StatefulConnection<byte[], byte[]>> asyncPool
     ) {
         super(defaultRedisCacheConfiguration, redisCacheConfiguration, conversionService, beanLocator);

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
@@ -4,6 +4,7 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.support.AsyncPool
 import io.micrometer.core.instrument.MeterRegistry
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
@@ -90,6 +91,49 @@ class RedisClientFactorySpec extends RedisSpec {
         client.getResources().ioThreadPoolSize() == 10
 
         cleanup:
+        applicationContext.stop()
+    }
+
+    void "test redis connection pool settings"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+                'redis.uri': RedisContainerUtils.getRedisPort("redis://localhost"),
+                'redis.pool.enabled': true,
+                'redis.pool.max-total': 2,
+                'redis.pool.min-idle': 1,
+        ])
+        AsyncPool<StatefulRedisConnection<String, String>> pool = applicationContext.getBean(AsyncPool)
+        StatefulRedisConnection<String, String> first = null
+        StatefulRedisConnection<String, String> second = null
+
+        when:
+        first = pool.acquire().get()
+        second = pool.acquire().get()
+
+        then:
+        first != null
+        second != null
+        !first.is(second)
+        first.isOpen()
+        second.isOpen()
+
+        when:
+        // tag::pooled-connections[]
+        first.sync().set("first", "one")
+        second.sync().set("second", "two")
+        // end::pooled-connections[]
+
+        then:
+        first.sync().get("first") == "one"
+        second.sync().get("second") == "two"
+
+        cleanup:
+        if (first != null) {
+            pool.release(first).get()
+        }
+        if (second != null) {
+            pool.release(second).get()
+        }
         applicationContext.stop()
     }
 

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
@@ -10,6 +10,8 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.redis.test.RedisContainerUtils
 
+import java.util.concurrent.TimeUnit
+
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -107,8 +109,8 @@ class RedisClientFactorySpec extends RedisSpec {
         StatefulRedisConnection<String, String> second = null
 
         when:
-        first = pool.acquire().get()
-        second = pool.acquire().get()
+        first = pool.acquire().get(5, TimeUnit.SECONDS)
+        second = pool.acquire().get(5, TimeUnit.SECONDS)
 
         then:
         first != null
@@ -129,10 +131,10 @@ class RedisClientFactorySpec extends RedisSpec {
 
         cleanup:
         if (first != null) {
-            pool.release(first).get()
+            pool.release(first).get(5, TimeUnit.SECONDS)
         }
         if (second != null) {
-            pool.release(second).get()
+            pool.release(second).get(5, TimeUnit.SECONDS)
         }
         applicationContext.stop()
     }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisClientFactorySpec.groovy
@@ -102,7 +102,6 @@ class RedisClientFactorySpec extends RedisSpec {
                 'redis.uri': RedisContainerUtils.getRedisPort("redis://localhost"),
                 'redis.pool.enabled': true,
                 'redis.pool.max-total': 2,
-                'redis.pool.min-idle': 1,
         ])
         AsyncPool<StatefulRedisConnection<String, String>> pool = applicationContext.getBean(AsyncPool)
         StatefulRedisConnection<String, String> first = null

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
@@ -133,6 +133,44 @@ class RedisConnectionPoolFactorySpec extends Specification {
         1 * replicaConnection.setReadFrom(_ as ReadFrom)
     }
 
+    void "creates standalone redis connections when replica uris are absent"() {
+        given:
+        RedisCodec<String, String> codec = Mock()
+        RedisClient redisClient = Mock()
+        StatefulRedisConnection<String, String> standaloneConnection = Mock()
+        RedisConnectionPoolFactory<String, String> factory = new RedisConnectionPoolFactory<>(codec)
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+        configuration.setUri(URI.create("redis://localhost:6379"))
+
+        when:
+        StatefulRedisConnection<String, String> connection = factory.createConnection(redisClient, configuration)
+
+        then:
+        connection.is(standaloneConnection)
+        1 * redisClient.connect(codec) >> standaloneConnection
+        0 * _
+    }
+
+    void "creates master replica redis connections without read from when not configured"() {
+        given:
+        RedisCodec<String, String> codec = Mock()
+        RedisClient redisClient = Mock()
+        StatefulRedisMasterReplicaConnection<String, String> replicaConnection = Mock()
+        TestRedisConnectionPoolFactory<String, String> factory = new TestRedisConnectionPoolFactory<>(codec)
+        factory.masterReplicaConnection = replicaConnection
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+        configuration.setUri(URI.create("redis://localhost:6379"))
+        configuration.setReplicaUris(URI.create("redis://localhost:6380"))
+
+        when:
+        StatefulRedisConnection<String, String> connection = factory.createConnection(redisClient, configuration)
+
+        then:
+        connection.is(replicaConnection)
+        factory.replicaUris*.port == [6380, 6379]
+        0 * replicaConnection.setReadFrom(_)
+    }
+
     void "creates a pool of redis cluster connections"() {
         given:
         RedisCodec<String, String> codec = Mock()
@@ -165,6 +203,24 @@ class RedisConnectionPoolFactorySpec extends Specification {
             }
             pool.close()
         }
+    }
+
+    void "creates cluster redis connections without read from when not configured"() {
+        given:
+        RedisCodec<String, String> codec = Mock()
+        RedisClusterClient redisClient = Mock()
+        StatefulRedisClusterConnection<String, String> clusterConnection = Mock()
+        RedisConnectionPoolFactory<String, String> factory = new RedisConnectionPoolFactory<>(codec)
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+
+        when:
+        StatefulRedisClusterConnection<String, String> connection = factory.createClusterConnection(redisClient, configuration)
+
+        then:
+        connection.is(clusterConnection)
+        1 * redisClient.connect(codec) >> clusterConnection
+        0 * clusterConnection.setReadFrom(_)
+        0 * _
     }
 
     void "injects byte array pool into cache beans when application pool is also present"() {

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
@@ -3,14 +3,19 @@ package io.micronaut.configuration.lettuce
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionStateListener
 import io.lettuce.core.ClientOptions
+import io.lettuce.core.ReadFrom
+import io.lettuce.core.RedisURI
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.push.PushListener
 import io.lettuce.core.api.reactive.RedisReactiveCommands
 import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.cluster.RedisClusterClient
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import io.lettuce.core.codec.ByteArrayCodec
 import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection
 import io.lettuce.core.protocol.RedisCommand
 import io.lettuce.core.resource.ClientResources
 import io.lettuce.core.support.AsyncPool
@@ -107,6 +112,61 @@ class RedisConnectionPoolFactorySpec extends Specification {
         applicationContext?.stop()
     }
 
+    void "creates master replica redis connections with the primary URI appended"() {
+        given:
+        RedisCodec<String, String> codec = Mock()
+        RedisClient redisClient = Mock()
+        StatefulRedisMasterReplicaConnection<String, String> replicaConnection = Mock()
+        TestRedisConnectionPoolFactory<String, String> factory = new TestRedisConnectionPoolFactory<>(codec)
+        factory.masterReplicaConnection = replicaConnection
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+        configuration.setUri(URI.create("redis://localhost:6379"))
+        configuration.setReplicaUris(URI.create("redis://localhost:6380"))
+        configuration.setReadFrom("MASTER")
+
+        when:
+        StatefulRedisConnection<String, String> connection = factory.createConnection(redisClient, configuration)
+
+        then:
+        connection.is(replicaConnection)
+        factory.replicaUris*.port == [6380, 6379]
+        1 * replicaConnection.setReadFrom(_ as ReadFrom)
+    }
+
+    void "creates a pool of redis cluster connections"() {
+        given:
+        RedisCodec<String, String> codec = Mock()
+        RedisClusterClient redisClient = Mock()
+        StatefulRedisClusterConnection<String, String> clusterConnection = Mock() {
+            isOpen() >> true
+            closeAsync() >> CompletableFuture.completedFuture(null)
+        }
+        RedisConnectionPoolFactory<String, String> factory = new RedisConnectionPoolFactory<>(codec)
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+        configuration.setReadFrom("MASTER")
+        DefaultRedisConnectionPoolConfiguration poolConfiguration = newPoolConfiguration()
+        StatefulRedisClusterConnection<String, String> acquired = null
+
+        and:
+        1 * redisClient.connect(codec) >> clusterConnection
+        1 * clusterConnection.setReadFrom(_ as ReadFrom)
+
+        when:
+        AsyncPool<StatefulRedisClusterConnection<String, String>> pool = factory.redisClusterConnectionPool(redisClient, configuration, poolConfiguration)
+        acquired = pool.acquire().get(5, TimeUnit.SECONDS)
+
+        then:
+        acquired.is(clusterConnection)
+
+        cleanup:
+        if (pool != null) {
+            if (acquired != null) {
+                pool.release(acquired).get(5, TimeUnit.SECONDS)
+            }
+            pool.close()
+        }
+    }
+
     void "injects byte array pool into cache beans when application pool is also present"() {
         given:
         ApplicationContext applicationContext = ApplicationContext.run([
@@ -143,6 +203,14 @@ class RedisConnectionPoolFactorySpec extends Specification {
         RedisClient redisClient() {
             return new TestRedisClient()
         }
+    }
+
+    private static DefaultRedisConnectionPoolConfiguration newPoolConfiguration() {
+        DefaultRedisConnectionPoolConfiguration poolConfiguration = new DefaultRedisConnectionPoolConfiguration(new ApplicationConfiguration())
+        poolConfiguration.maxTotal = 1
+        poolConfiguration.maxIdle = 1
+        poolConfiguration.minIdle = 0
+        return poolConfiguration
     }
 
     private static final class TestRedisClient extends RedisClient {
@@ -260,5 +328,20 @@ class RedisConnectionPoolFactorySpec extends Specification {
     }
 
     private static final class ByteArrayTestStatefulRedisConnection extends TestStatefulRedisConnection<byte[], byte[]> {
+    }
+
+    private static final class TestRedisConnectionPoolFactory<K, V> extends RedisConnectionPoolFactory<K, V> {
+        StatefulRedisMasterReplicaConnection<K, V> masterReplicaConnection
+        List<RedisURI> replicaUris
+
+        TestRedisConnectionPoolFactory(RedisCodec<K, V> defaultCodec) {
+            super(defaultCodec)
+        }
+
+        @Override
+        StatefulRedisMasterReplicaConnection<K, V> createMasterReplicaConnection(RedisClient redisClient, List<RedisURI> redisUris) {
+            replicaUris = redisUris
+            return masterReplicaConnection
+        }
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
@@ -4,10 +4,12 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionStateListener
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.push.PushListener
 import io.lettuce.core.api.reactive.RedisReactiveCommands
 import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.codec.ByteArrayCodec
 import io.lettuce.core.codec.RedisCodec
 import io.lettuce.core.protocol.RedisCommand
 import io.lettuce.core.resource.ClientResources
@@ -16,6 +18,9 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
+import io.micronaut.configuration.lettuce.cache.RedisAsyncConnectionPoolFactory
+import io.micronaut.configuration.lettuce.cache.RedisConnectionPoolCache
+import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.runtime.ApplicationConfiguration
 import jakarta.inject.Singleton
 import spock.lang.Specification
@@ -73,6 +78,7 @@ class RedisConnectionPoolFactorySpec extends Specification {
             'spec.name'          : SPEC_NAME,
             'redis.uri'          : 'redis://localhost',
             'redis.pool.enabled' : true,
+            'redis.pool.min-idle': 0,
             'redis.pool.max-total': 2,
         ])
         AsyncPool<StatefulRedisConnection<String, String>> pool = applicationContext.getBean(AsyncPool)
@@ -101,6 +107,34 @@ class RedisConnectionPoolFactorySpec extends Specification {
         applicationContext?.stop()
     }
 
+    void "injects byte array pool into cache beans when application pool is also present"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+            'spec.name'                 : SPEC_NAME,
+            'redis.uri'                 : 'redis://localhost',
+            'redis.pool.enabled'        : true,
+            'redis.pool.min-idle'       : 0,
+            'redis.pool.max-total'      : 2,
+            'redis.caches.test.enabled' : true,
+        ])
+
+        when:
+        RedisConnectionPoolCache redisCache = applicationContext.getBean(RedisConnectionPoolCache, Qualifiers.byName("test"))
+        AsyncPool<StatefulRedisConnection<String, String>> applicationPool = applicationContext.getBean(AsyncPool)
+        AsyncPool<StatefulConnection<byte[], byte[]>> cachePool = applicationContext.getBean(
+            AsyncPool,
+            Qualifiers.byName(RedisAsyncConnectionPoolFactory.CACHE_POOL_BEAN)
+        )
+
+        then:
+        redisCache != null
+        applicationPool != null
+        cachePool.is(redisCache.getNativeCache())
+
+        cleanup:
+        applicationContext?.stop()
+    }
+
     @Factory
     @Requires(property = 'spec.name', value = SPEC_NAME)
     static class TestRedisClientFactory {
@@ -118,11 +152,14 @@ class RedisConnectionPoolFactorySpec extends Specification {
 
         @Override
         <K, V> StatefulRedisConnection<K, V> connect(RedisCodec<K, V> codec) {
+            if (codec instanceof ByteArrayCodec) {
+                return (StatefulRedisConnection<K, V>) new ByteArrayTestStatefulRedisConnection()
+            }
             return new TestStatefulRedisConnection<>()
         }
     }
 
-    private static final class TestStatefulRedisConnection<K, V> implements StatefulRedisConnection<K, V> {
+    private static class TestStatefulRedisConnection<K, V> implements StatefulRedisConnection<K, V> {
         private boolean open = true
         private Duration timeout = Duration.ofSeconds(60)
 
@@ -220,5 +257,8 @@ class RedisConnectionPoolFactorySpec extends Specification {
         RedisCodec<K, V> getCodec() {
             return null
         }
+    }
+
+    private static final class ByteArrayTestStatefulRedisConnection extends TestStatefulRedisConnection<byte[], byte[]> {
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
@@ -23,6 +23,7 @@ import spock.lang.Specification
 import java.net.URI
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 
 class RedisConnectionPoolFactorySpec extends Specification {
     private static final String SPEC_NAME = "redis-connection-pool-factory"
@@ -45,8 +46,8 @@ class RedisConnectionPoolFactorySpec extends Specification {
 
         when:
         AsyncPool<StatefulRedisConnection<String, String>> pool = factory.redisConnectionPool(redisClient, configuration, poolConfiguration)
-        StatefulRedisConnection<String, String> acquiredFirst = pool.acquire().get()
-        StatefulRedisConnection<String, String> acquiredSecond = pool.acquire().get()
+        StatefulRedisConnection<String, String> acquiredFirst = pool.acquire().get(5, TimeUnit.SECONDS)
+        StatefulRedisConnection<String, String> acquiredSecond = pool.acquire().get(5, TimeUnit.SECONDS)
 
         then:
         acquiredFirst.is(first)
@@ -57,10 +58,10 @@ class RedisConnectionPoolFactorySpec extends Specification {
         cleanup:
         if (pool != null) {
             if (acquiredFirst != null) {
-                pool.release(acquiredFirst).get()
+                pool.release(acquiredFirst).get(5, TimeUnit.SECONDS)
             }
             if (acquiredSecond != null) {
-                pool.release(acquiredSecond).get()
+                pool.release(acquiredSecond).get(5, TimeUnit.SECONDS)
             }
             pool.close()
         }
@@ -79,8 +80,8 @@ class RedisConnectionPoolFactorySpec extends Specification {
         StatefulRedisConnection<String, String> acquiredSecond = null
 
         when:
-        acquiredFirst = pool.acquire().get()
-        acquiredSecond = pool.acquire().get()
+        acquiredFirst = pool.acquire().get(5, TimeUnit.SECONDS)
+        acquiredSecond = pool.acquire().get(5, TimeUnit.SECONDS)
 
         then:
         acquiredFirst instanceof TestStatefulRedisConnection
@@ -90,10 +91,10 @@ class RedisConnectionPoolFactorySpec extends Specification {
         cleanup:
         if (pool != null) {
             if (acquiredFirst != null) {
-                pool.release(acquiredFirst).get()
+                pool.release(acquiredFirst).get(5, TimeUnit.SECONDS)
             }
             if (acquiredSecond != null) {
-                pool.release(acquiredSecond).get()
+                pool.release(acquiredSecond).get(5, TimeUnit.SECONDS)
             }
             pool.close()
         }
@@ -111,6 +112,10 @@ class RedisConnectionPoolFactorySpec extends Specification {
     }
 
     private static final class TestRedisClient extends RedisClient {
+        TestRedisClient() {
+            super()
+        }
+
         @Override
         <K, V> StatefulRedisConnection<K, V> connect(RedisCodec<K, V> codec) {
             return new TestStatefulRedisConnection<>()

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConnectionPoolFactorySpec.groovy
@@ -1,0 +1,219 @@
+package io.micronaut.configuration.lettuce
+
+import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisConnectionStateListener
+import io.lettuce.core.ClientOptions
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisAsyncCommands
+import io.lettuce.core.api.push.PushListener
+import io.lettuce.core.api.reactive.RedisReactiveCommands
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.protocol.RedisCommand
+import io.lettuce.core.resource.ClientResources
+import io.lettuce.core.support.AsyncPool
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.runtime.ApplicationConfiguration
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.net.URI
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
+class RedisConnectionPoolFactorySpec extends Specification {
+    private static final String SPEC_NAME = "redis-connection-pool-factory"
+
+    void "creates a pool of redis connections"() {
+        given:
+        RedisCodec<String, String> codec = Mock()
+        RedisClient redisClient = Stub()
+        StatefulRedisConnection<String, String> first = new TestStatefulRedisConnection<>()
+        StatefulRedisConnection<String, String> second = new TestStatefulRedisConnection<>()
+        RedisConnectionPoolFactory<String, String> factory = new RedisConnectionPoolFactory<>(codec)
+        DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
+        configuration.setUri(URI.create("redis://localhost"))
+        DefaultRedisConnectionPoolConfiguration poolConfiguration = new DefaultRedisConnectionPoolConfiguration(new ApplicationConfiguration())
+        poolConfiguration.maxTotal = 2
+        poolConfiguration.maxIdle = 2
+        poolConfiguration.minIdle = 0
+
+        redisClient.connect(codec) >>> [first, second]
+
+        when:
+        AsyncPool<StatefulRedisConnection<String, String>> pool = factory.redisConnectionPool(redisClient, configuration, poolConfiguration)
+        StatefulRedisConnection<String, String> acquiredFirst = pool.acquire().get()
+        StatefulRedisConnection<String, String> acquiredSecond = pool.acquire().get()
+
+        then:
+        acquiredFirst.is(first)
+        acquiredSecond.is(second)
+        acquiredFirst.isOpen()
+        acquiredSecond.isOpen()
+
+        cleanup:
+        if (pool != null) {
+            if (acquiredFirst != null) {
+                pool.release(acquiredFirst).get()
+            }
+            if (acquiredSecond != null) {
+                pool.release(acquiredSecond).get()
+            }
+            pool.close()
+        }
+    }
+
+    void "registers a pool bean for application code"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+            'spec.name'          : SPEC_NAME,
+            'redis.uri'          : 'redis://localhost',
+            'redis.pool.enabled' : true,
+            'redis.pool.max-total': 2,
+        ])
+        AsyncPool<StatefulRedisConnection<String, String>> pool = applicationContext.getBean(AsyncPool)
+        StatefulRedisConnection<String, String> acquiredFirst = null
+        StatefulRedisConnection<String, String> acquiredSecond = null
+
+        when:
+        acquiredFirst = pool.acquire().get()
+        acquiredSecond = pool.acquire().get()
+
+        then:
+        acquiredFirst instanceof TestStatefulRedisConnection
+        acquiredSecond instanceof TestStatefulRedisConnection
+        !acquiredFirst.is(acquiredSecond)
+
+        cleanup:
+        if (pool != null) {
+            if (acquiredFirst != null) {
+                pool.release(acquiredFirst).get()
+            }
+            if (acquiredSecond != null) {
+                pool.release(acquiredSecond).get()
+            }
+            pool.close()
+        }
+        applicationContext?.stop()
+    }
+
+    @Factory
+    @Requires(property = 'spec.name', value = SPEC_NAME)
+    static class TestRedisClientFactory {
+        @Singleton
+        @Replaces(RedisClient)
+        RedisClient redisClient() {
+            return new TestRedisClient()
+        }
+    }
+
+    private static final class TestRedisClient extends RedisClient {
+        @Override
+        <K, V> StatefulRedisConnection<K, V> connect(RedisCodec<K, V> codec) {
+            return new TestStatefulRedisConnection<>()
+        }
+    }
+
+    private static final class TestStatefulRedisConnection<K, V> implements StatefulRedisConnection<K, V> {
+        private boolean open = true
+        private Duration timeout = Duration.ofSeconds(60)
+
+        @Override
+        boolean isMulti() {
+            return false
+        }
+
+        @Override
+        RedisCommands<K, V> sync() {
+            return null
+        }
+
+        @Override
+        RedisAsyncCommands<K, V> async() {
+            return null
+        }
+
+        @Override
+        RedisReactiveCommands<K, V> reactive() {
+            return null
+        }
+
+        @Override
+        void addListener(PushListener listener) {
+        }
+
+        @Override
+        void removeListener(PushListener listener) {
+        }
+
+        @Override
+        void addListener(RedisConnectionStateListener listener) {
+        }
+
+        @Override
+        void removeListener(RedisConnectionStateListener listener) {
+        }
+
+        @Override
+        void setTimeout(Duration timeout) {
+            this.timeout = timeout
+        }
+
+        @Override
+        Duration getTimeout() {
+            return timeout
+        }
+
+        @Override
+        <T> RedisCommand<K, V, T> dispatch(RedisCommand<K, V, T> command) {
+            return command
+        }
+
+        @Override
+        Collection<RedisCommand<K, V, ?>> dispatch(Collection<? extends RedisCommand<K, V, ?>> commands) {
+            return commands
+        }
+
+        @Override
+        void close() {
+            open = false
+        }
+
+        @Override
+        CompletableFuture<Void> closeAsync() {
+            open = false
+            return CompletableFuture.completedFuture(null)
+        }
+
+        @Override
+        boolean isOpen() {
+            return open
+        }
+
+        @Override
+        ClientOptions getOptions() {
+            return null
+        }
+
+        @Override
+        ClientResources getResources() {
+            return null
+        }
+
+        @Override
+        void setAutoFlushCommands(boolean autoFlush) {
+        }
+
+        @Override
+        void flushCommands() {
+        }
+
+        @Override
+        RedisCodec<K, V> getCodec() {
+            return null
+        }
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.configuration.lettuce.cache
 
 import groovy.transform.Canonical
+import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.support.AsyncPool
 import io.micronaut.configuration.lettuce.AbstractRedisConnectionPoolConfiguration
 import io.micronaut.configuration.lettuce.RedisSpec
@@ -209,7 +210,7 @@ class RedisPoolCacheSpec extends RedisSpec {
                 cacheConfig,
                 ConversionService.SHARED,
                 applicationContext.getBean(BeanLocator.class),
-                applicationContext.getBean(AsyncPool.class)
+                applicationContext.getBean(AsyncPool.class, Qualifiers.byName(RedisAsyncConnectionPoolFactory.CACHE_POOL_BEAN))
         )
 
         then:
@@ -234,7 +235,7 @@ class RedisPoolCacheSpec extends RedisSpec {
                 cacheConfig,
                 ConversionService.SHARED,
                 applicationContext.getBean(BeanLocator.class),
-                applicationContext.getBean(AsyncPool.class)
+                applicationContext.getBean(AsyncPool.class, Qualifiers.byName(RedisAsyncConnectionPoolFactory.CACHE_POOL_BEAN))
         )
 
         then:
@@ -259,7 +260,7 @@ class RedisPoolCacheSpec extends RedisSpec {
                 cacheConfig,
                 ConversionService.SHARED,
                 applicationContext.getBean(BeanLocator.class),
-                applicationContext.getBean(AsyncPool.class)
+                applicationContext.getBean(AsyncPool.class, Qualifiers.byName(RedisAsyncConnectionPoolFactory.CACHE_POOL_BEAN))
         )
 
         then:

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -81,6 +81,8 @@ Then inject `io.lettuce.core.support.AsyncPool<io.lettuce.core.api.StatefulRedis
 ----
 include::{testsredis}/RedisClientFactorySpec.groovy[tags=pooled-connections, indent=0]
 ----
+
+If you configure Redis as a cluster with `redis.uris`, Micronaut instead exposes `io.lettuce.core.support.AsyncPool<io.lettuce.core.cluster.api.StatefulRedisClusterConnection<K, V>>` so you can borrow pooled cluster connections for the same pattern.
 ====
 
 
@@ -91,6 +93,7 @@ Once you have the above configuration in place you can inject one of the followi
 * `io.lettuce.core.RedisClient` - The main client interface
 * `io.lettuce.core.api.StatefulRedisConnection` - A connection interface that features synchronous, reactive (based on Reactor) and async APIs that operate on `String` values
 * `io.lettuce.core.support.AsyncPool<io.lettuce.core.api.StatefulRedisConnection<K, V>>` - An optional pool for borrowing multiple connections when you need parallel Redis work
+* `io.lettuce.core.support.AsyncPool<io.lettuce.core.cluster.api.StatefulRedisClusterConnection<K, V>>` - An optional cluster-aware pool available when `redis.uris` is configured
 * `io.lettuce.core.pubsub.StatefulRedisPubSubConnection` - A connection interface for dealing with Redis Pub/Sub
 
 The following example demonstrates the use of the `StatefulRedisConnection` interface's synchronous API:

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -90,7 +90,7 @@ Once you have the above configuration in place you can inject one of the followi
 
 * `io.lettuce.core.RedisClient` - The main client interface
 * `io.lettuce.core.api.StatefulRedisConnection` - A connection interface that features synchronous, reactive (based on Reactor) and async APIs that operate on `String` values
-* `io.lettuce.core.support.AsyncPool<io.lettuce.core.api.StatefulRedisConnection>` - An optional pool for borrowing multiple connections when you need parallel Redis work
+* `io.lettuce.core.support.AsyncPool<io.lettuce.core.api.StatefulRedisConnection<K, V>>` - An optional pool for borrowing multiple connections when you need parallel Redis work
 * `io.lettuce.core.pubsub.StatefulRedisPubSubConnection` - A connection interface for dealing with Redis Pub/Sub
 
 The following example demonstrates the use of the `StatefulRedisConnection` interface's synchronous API:

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -58,6 +58,31 @@ https://github.com/lettuce-io/lettuce-core/wiki/Configuring-Client-resources
 
 IMPORTANT: You may see `io.lettuce.core.RedisCommandTimeoutException: Command timed out after` if your code is blocking Lettuce's asynchronous execution because of the default value of the thread pool size being small.
 
+IMPORTANT: Increasing `io-thread-pool-size` or `computation-thread-pool-size` does not make a single `StatefulRedisConnection` process commands on multiple Redis connections. A long-lived Lettuce connection still uses a single underlying channel. If you need parallel reactive work across multiple Redis connections, enable `redis.pool` and borrow separate connections from the pool.
+
+====
+Pooled connections for parallel reactive commands
+
+Micronaut can create a Lettuce connection pool for application code:
+
+[configuration]
+----
+redis:
+    uri: redis://localhost
+    pool:
+        enabled: true
+        max-total: 16
+        min-idle: 4
+----
+
+Then inject `io.lettuce.core.support.AsyncPool<io.lettuce.core.api.StatefulRedisConnection<K, V>>` and release each acquired connection after use:
+
+[source,groovy]
+----
+include::{testsredis}/RedisClientFactorySpec.groovy[tags=pooled-connections, indent=0]
+----
+====
+
 
 === Available Lettuce Beans
 
@@ -65,6 +90,7 @@ Once you have the above configuration in place you can inject one of the followi
 
 * `io.lettuce.core.RedisClient` - The main client interface
 * `io.lettuce.core.api.StatefulRedisConnection` - A connection interface that features synchronous, reactive (based on Reactor) and async APIs that operate on `String` values
+* `io.lettuce.core.support.AsyncPool<io.lettuce.core.api.StatefulRedisConnection>` - An optional pool for borrowing multiple connections when you need parallel Redis work
 * `io.lettuce.core.pubsub.StatefulRedisPubSubConnection` - A connection interface for dealing with Redis Pub/Sub
 
 The following example demonstrates the use of the `StatefulRedisConnection` interface's synchronous API:


### PR DESCRIPTION
## Summary
- add an application-level Lettuce connection pool bean for borrowing multiple stateful Redis connections
- cover the new pool factory with focused tests and document how it differs from Lettuce thread-pool sizing
- include an integration-style usage example for pooled connections

## Verification
- ./gradlew :micronaut-redis-lettuce:test --tests io.micronaut.configuration.lettuce.RedisConnectionPoolFactorySpec
- ./gradlew :micronaut-redis-lettuce:spotlessCheck

Resolves #473