### PR TITLE
Fix session namespace derived Redis keys

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/session/RedisHttpSessionConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/session/RedisHttpSessionConfiguration.java
@@ -36,10 +36,13 @@ import java.util.Optional;
 @ConfigurationProperties(RedisSetting.PREFIX)
 public class RedisHttpSessionConfiguration extends HttpSessionConfiguration implements Toggleable {
 
+    private static final String SESSION_CREATED_TOPIC_SUFFIX = "event:session-created";
+    private static final String ACTIVE_SESSIONS_KEY_SUFFIX = "active-sessions";
+
     private String namespace = "micronaut:session:";
     private String serverName;
-    private String sessionCreatedTopic = namespace + "event:session-created";
-    private String activeSessionsKey = namespace + "active-sessions";
+    private String sessionCreatedTopic;
+    private String activeSessionsKey;
     private Class<ObjectSerializer> valueSerializer;
     private Charset charset = StandardCharsets.UTF_8;
     private boolean enableKeyspaceEvents = true;
@@ -64,14 +67,14 @@ public class RedisHttpSessionConfiguration extends HttpSessionConfiguration impl
      * @return The topic to use to publish the creation of new sessions.
      */
     public String getSessionCreatedTopic() {
-        return sessionCreatedTopic;
+        return sessionCreatedTopic != null ? sessionCreatedTopic : namespace + SESSION_CREATED_TOPIC_SUFFIX;
     }
 
     /**
      * @return The key of the sorted set used to maintain a set of active sessions.
      */
     public String getActiveSessionsKey() {
-        return activeSessionsKey;
+        return activeSessionsKey != null ? activeSessionsKey : namespace + ACTIVE_SESSIONS_KEY_SUFFIX;
     }
 
     /**

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/session/RedisHttpSessionConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/session/RedisHttpSessionConfigurationSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.configuration.lettuce.session
+
+import spock.lang.Specification
+
+class RedisHttpSessionConfigurationSpec extends Specification {
+
+    void "namespace updates derived session defaults"() {
+        given:
+        def configuration = new RedisHttpSessionConfiguration()
+
+        when:
+        configuration.setNamespace("myapp:sessions:")
+
+        then:
+        configuration.namespace == "myapp:sessions:"
+        configuration.activeSessionsKey == "myapp:sessions:active-sessions"
+        configuration.sessionCreatedTopic == "myapp:sessions:event:session-created"
+    }
+
+    void "explicit session keys are preserved across namespace changes"() {
+        given:
+        def configuration = new RedisHttpSessionConfiguration()
+
+        when:
+        configuration.setActiveSessionsKey("shared:active-sessions")
+        configuration.setSessionCreatedTopic("shared:event:session-created")
+        configuration.setNamespace("myapp:sessions:")
+
+        then:
+        configuration.activeSessionsKey == "shared:active-sessions"
+        configuration.sessionCreatedTopic == "shared:event:session-created"
+    }
+}


### PR DESCRIPTION
## Summary
- derive `activeSessionsKey` and `sessionCreatedTopic` from the configured session namespace when they are not explicitly overridden
- preserve explicit overrides for both properties across namespace changes
- add a focused regression spec covering the derived and explicit-key cases

## Verification
- `./gradlew :micronaut-redis-lettuce:test --tests 'io.micronaut.configuration.lettuce.session.RedisHttpSessionConfigurationSpec' --rerun-tasks`\n\nResolves #81