### PR TITLE
Support bulk get, put, and invalidate

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
@@ -30,7 +30,6 @@ import io.micronaut.configuration.lettuce.cache.expiration.ExpirationAfterWriteP
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.serialize.JdkSerializer;
 import io.micronaut.core.serialize.ObjectSerializer;
 import io.micronaut.core.type.Argument;
@@ -292,12 +291,14 @@ public abstract class AbstractRedisCache<C> implements SyncCache<C>, AutoCloseab
             K key = orderedKeys.get(i);
             KeyValue<byte[], byte[]> value = values.get(i);
             if (value != null && value.hasValue()) {
-                T deserialized = valueSerializer.deserialize(value.getValue(), requiredType)
-                    .orElseThrow(() -> new ConversionErrorException(requiredType,
-                        new IllegalArgumentException("Cannot convert cached value for [" + key + "] to target type: " + requiredType.getType())));
-                resolved.put(key, deserialized);
-                if (expireAfterAccess != null) {
-                    redisKeyCommands.pexpire(serializedKeys[i], expireAfterAccess);
+                Optional<T> deserialized = valueSerializer.deserialize(value.getValue(), requiredType);
+                if (deserialized.isPresent()) {
+                    resolved.put(key, deserialized.get());
+                    if (expireAfterAccess != null) {
+                        redisKeyCommands.pexpire(serializedKeys[i], expireAfterAccess);
+                    }
+                } else {
+                    resolved.put(key, null);
                 }
             } else {
                 resolved.put(key, null);
@@ -344,9 +345,10 @@ public abstract class AbstractRedisCache<C> implements SyncCache<C>, AutoCloseab
         });
 
         if (!toSave.isEmpty()) {
-            redisStringCommands.mset(toSave);
             if (toExpire != null) {
-                toExpire.forEach(redisKeyCommands::pexpire);
+                toSave.forEach((k, v) -> redisStringCommands.psetex(k, toExpire.get(k), v));
+            } else {
+                redisStringCommands.mset(toSave);
             }
         }
         if (!toDelete.isEmpty()) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/AbstractRedisCache.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.lettuce.cache;
 
+import io.lettuce.core.KeyValue;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisKeyAsyncCommands;
@@ -29,13 +30,20 @@ import io.micronaut.configuration.lettuce.cache.expiration.ExpirationAfterWriteP
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.serialize.JdkSerializer;
 import io.micronaut.core.serialize.ObjectSerializer;
 import io.micronaut.core.type.Argument;
+import org.jspecify.annotations.NonNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.Optional;
 
 /**
  * An abstract class implementing SyncCache for the redis.
@@ -247,6 +255,117 @@ public abstract class AbstractRedisCache<C> implements SyncCache<C>, AutoCloseab
         } else {
             redisKeyCommands.del(serializedKey);
         }
+    }
+
+    /**
+     * Resolve the values for the given keys and convert them to the required type.
+     *
+     * @param keys               The cache keys
+     * @param requiredType       The required type
+     * @param redisStringCommands The redis string commands
+     * @param redisKeyCommands   The redis key commands
+     * @param <K>                The type of the unserialized key
+     * @param <T>                The concrete type
+     * @return An ordered map containing all requested keys in the original order
+     */
+    protected <K, T> Map<K, T> getValues(
+        @NonNull Collection<K> keys,
+        @NonNull Argument<T> requiredType,
+        RedisStringCommands<byte[], byte[]> redisStringCommands,
+        RedisKeyCommands<byte[], byte[]> redisKeyCommands
+    ) {
+        if (keys.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        List<K> orderedKeys = new ArrayList<>(keys.size());
+        byte[][] serializedKeys = new byte[keys.size()][];
+        int index = 0;
+        for (K key : keys) {
+            orderedKeys.add(key);
+            serializedKeys[index++] = serializeKey(key);
+        }
+
+        List<KeyValue<byte[], byte[]>> values = redisStringCommands.mget(serializedKeys);
+        Map<K, T> resolved = new LinkedHashMap<>(orderedKeys.size());
+        for (int i = 0; i < orderedKeys.size(); i++) {
+            K key = orderedKeys.get(i);
+            KeyValue<byte[], byte[]> value = values.get(i);
+            if (value != null && value.hasValue()) {
+                T deserialized = valueSerializer.deserialize(value.getValue(), requiredType)
+                    .orElseThrow(() -> new ConversionErrorException(requiredType,
+                        new IllegalArgumentException("Cannot convert cached value for [" + key + "] to target type: " + requiredType.getType())));
+                resolved.put(key, deserialized);
+                if (expireAfterAccess != null) {
+                    redisKeyCommands.pexpire(serializedKeys[i], expireAfterAccess);
+                }
+            } else {
+                resolved.put(key, null);
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Cache the specified values in bulk.
+     *
+     * @param values The values to store
+     * @param redisStringCommands The redis string commands
+     * @param redisKeyCommands The redis key commands
+     */
+    protected void putValues(
+        @NonNull Map<?, ?> values,
+        RedisStringCommands<byte[], byte[]> redisStringCommands,
+        RedisKeyCommands<byte[], byte[]> redisKeyCommands
+    ) {
+        if (values.isEmpty()) {
+            return;
+        }
+
+        Map<byte[], byte[]> toSave = new LinkedHashMap<>(values.size());
+        Map<byte[], Long> toExpire = expireAfterWritePolicy == null ? null : new LinkedHashMap<>(values.size());
+        List<byte[]> toDelete = new ArrayList<>(values.size());
+        values.forEach((key, value) -> {
+            byte[] serializedKey = serializeKey(key);
+            if (value == null) {
+                toDelete.add(serializedKey);
+                return;
+            }
+
+            Optional<byte[]> serialized = valueSerializer.serialize(value);
+            if (serialized.isPresent()) {
+                toSave.put(serializedKey, serialized.get());
+                if (toExpire != null) {
+                    toExpire.put(serializedKey, expireAfterWritePolicy.getExpirationAfterWrite(value));
+                }
+            } else {
+                toDelete.add(serializedKey);
+            }
+        });
+
+        if (!toSave.isEmpty()) {
+            redisStringCommands.mset(toSave);
+            if (toExpire != null) {
+                toExpire.forEach(redisKeyCommands::pexpire);
+            }
+        }
+        if (!toDelete.isEmpty()) {
+            redisKeyCommands.del(toDelete.toArray(new byte[0][]));
+        }
+    }
+
+    /**
+     * Invalidate the values for the given keys.
+     *
+     * @param keys The keys to invalidate
+     * @param redisKeyCommands The redis key commands
+     */
+    protected void invalidateValues(@NonNull Collection<?> keys, RedisKeyCommands<byte[], byte[]> redisKeyCommands) {
+        if (keys.isEmpty()) {
+            return;
+        }
+        byte[][] serializedKeys = keys.stream().map(this::serializeKey).toArray(byte[][]::new);
+        redisKeyCommands.del(serializedKeys);
     }
 
     /**

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -34,8 +34,10 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import jakarta.annotation.PreDestroy;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -106,10 +108,54 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
         return get(serializedKey, requiredType, supplier, redisStringCommands);
     }
 
+    /**
+     * Resolve the values for the given keys.
+     *
+     * @param keys The cache keys
+     * @param <K> The key type
+     * @return An ordered map containing all requested keys
+     */
+    @NonNull
+    public <K> Map<K, Object> get(@NonNull Collection<K> keys) {
+        return get(keys, Argument.OBJECT_ARGUMENT);
+    }
+
+    /**
+     * Resolve the values for the given keys.
+     *
+     * @param keys The cache keys
+     * @param requiredType The required type
+     * @param <K> The key type
+     * @param <T> The value type
+     * @return An ordered map containing all requested keys
+     */
+    @NonNull
+    public <K, T> Map<K, T> get(@NonNull Collection<K> keys, @NonNull Argument<T> requiredType) {
+        return getValues(keys, requiredType, redisStringCommands, redisKeyCommands);
+    }
+
+    /**
+     * Cache the specified values in bulk.
+     *
+     * @param values The values to cache
+     */
+    public void put(@NonNull Map<?, ?> values) {
+        putValues(values, redisStringCommands, redisKeyCommands);
+    }
+
     @Override
     public void invalidate(Object key) {
         byte[] serializedKey = serializeKey(key);
         redisKeyCommands.del(serializedKey);
+    }
+
+    /**
+     * Invalidate the values for the given keys.
+     *
+     * @param keys The keys to invalidate
+     */
+    public void invalidate(@NonNull Collection<?> keys) {
+        invalidateValues(keys, redisKeyCommands);
     }
 
     @Override

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -116,8 +116,8 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
      * @return An ordered map containing all requested keys
      */
     @NonNull
-    public <K> Map<K, Object> get(@NonNull Collection<K> keys) {
-        return get(keys, Argument.OBJECT_ARGUMENT);
+    public <K> Map<K, Object> getAll(@NonNull Collection<K> keys) {
+        return getAll(keys, Argument.OBJECT_ARGUMENT);
     }
 
     /**
@@ -130,7 +130,7 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
      * @return An ordered map containing all requested keys
      */
     @NonNull
-    public <K, T> Map<K, T> get(@NonNull Collection<K> keys, @NonNull Argument<T> requiredType) {
+    public <K, T> Map<K, T> getAll(@NonNull Collection<K> keys, @NonNull Argument<T> requiredType) {
         return getValues(keys, requiredType, redisStringCommands, redisKeyCommands);
     }
 
@@ -139,7 +139,7 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
      *
      * @param values The values to cache
      */
-    public void put(@NonNull Map<?, ?> values) {
+    public void putAll(@NonNull Map<?, ?> values) {
         putValues(values, redisStringCommands, redisKeyCommands);
     }
 
@@ -154,7 +154,7 @@ public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], by
      *
      * @param keys The keys to invalidate
      */
-    public void invalidate(@NonNull Collection<?> keys) {
+    public void invalidateAllKeys(@NonNull Collection<?> keys) {
         invalidateValues(keys, redisKeyCommands);
     }
 

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
@@ -38,9 +38,11 @@ import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -106,6 +108,57 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
         }).join();
     }
 
+    /**
+     * Resolve the values for the given keys.
+     *
+     * @param keys The cache keys
+     * @param <K> The key type
+     * @return An ordered map containing all requested keys
+     */
+    @NonNull
+    public <K> Map<K, Object> get(@NonNull Collection<K> keys) {
+        return get(keys, Argument.OBJECT_ARGUMENT);
+    }
+
+    /**
+     * Resolve the values for the given keys.
+     *
+     * @param keys The cache keys
+     * @param requiredType The required type
+     * @param <K> The key type
+     * @param <T> The value type
+     * @return An ordered map containing all requested keys
+     */
+    @NonNull
+    public <K, T> Map<K, T> get(@NonNull Collection<K> keys, @NonNull Argument<T> requiredType) {
+        return asyncPool.acquire().thenCompose(connection -> {
+            try {
+                RedisStringCommands<byte[], byte[]> stringCommands = getRedisStringCommands(connection);
+                RedisKeyCommands<byte[], byte[]> keyCommands = getRedisKeyCommands(connection);
+                return CompletableFuture.completedFuture(getValues(keys, requiredType, stringCommands, keyCommands));
+            } finally {
+                asyncPool.release(connection);
+            }
+        }).join();
+    }
+
+    /**
+     * Cache the specified values in bulk.
+     *
+     * @param values The values to cache
+     */
+    public void put(@NonNull Map<?, ?> values) {
+        asyncPool.acquire().thenAccept(connection -> {
+            try {
+                RedisStringCommands<byte[], byte[]> stringCommands = getRedisStringCommands(connection);
+                RedisKeyCommands<byte[], byte[]> keyCommands = getRedisKeyCommands(connection);
+                putValues(values, stringCommands, keyCommands);
+            } finally {
+                asyncPool.release(connection);
+            }
+        }).join();
+    }
+
     @Override
     public void invalidate(Object key) {
         byte[] serializedKey = serializeKey(key);
@@ -113,6 +166,22 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
             try {
                 RedisKeyCommands<byte[], byte[]> commands = getRedisKeyCommands(connection);
                 invalidate(Collections.singletonList(serializedKey), commands);
+            } finally {
+                asyncPool.release(connection);
+            }
+        }).join();
+    }
+
+    /**
+     * Invalidate the values for the given keys.
+     *
+     * @param keys The keys to invalidate
+     */
+    public void invalidate(@NonNull Collection<?> keys) {
+        asyncPool.acquire().thenAccept(connection -> {
+            try {
+                RedisKeyCommands<byte[], byte[]> commands = getRedisKeyCommands(connection);
+                invalidateValues(keys, commands);
             } finally {
                 asyncPool.release(connection);
             }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
@@ -116,8 +116,8 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
      * @return An ordered map containing all requested keys
      */
     @NonNull
-    public <K> Map<K, Object> get(@NonNull Collection<K> keys) {
-        return get(keys, Argument.OBJECT_ARGUMENT);
+    public <K> Map<K, Object> getAll(@NonNull Collection<K> keys) {
+        return getAll(keys, Argument.OBJECT_ARGUMENT);
     }
 
     /**
@@ -130,7 +130,7 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
      * @return An ordered map containing all requested keys
      */
     @NonNull
-    public <K, T> Map<K, T> get(@NonNull Collection<K> keys, @NonNull Argument<T> requiredType) {
+    public <K, T> Map<K, T> getAll(@NonNull Collection<K> keys, @NonNull Argument<T> requiredType) {
         return asyncPool.acquire().thenCompose(connection -> {
             try {
                 RedisStringCommands<byte[], byte[]> stringCommands = getRedisStringCommands(connection);
@@ -147,7 +147,7 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
      *
      * @param values The values to cache
      */
-    public void put(@NonNull Map<?, ?> values) {
+    public void putAll(@NonNull Map<?, ?> values) {
         asyncPool.acquire().thenAccept(connection -> {
             try {
                 RedisStringCommands<byte[], byte[]> stringCommands = getRedisStringCommands(connection);
@@ -177,7 +177,7 @@ public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<State
      *
      * @param keys The keys to invalidate
      */
-    public void invalidate(@NonNull Collection<?> keys) {
+    public void invalidateAllKeys(@NonNull Collection<?> keys) {
         asyncPool.acquire().thenAccept(connection -> {
             try {
                 RedisKeyCommands<byte[], byte[]> commands = getRedisKeyCommands(connection);

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
@@ -235,7 +235,7 @@ class RedisCacheSpec extends RedisSpec {
         when:
         RedisCache redisCache = applicationContext.getBean(RedisCache, Qualifiers.byName("test"))
         redisCache.put("deleteme", "should get deleted")
-        redisCache.put([
+        redisCache.putAll([
                 "three": 3,
                 "test" : new Foo(name: "test"),
                 "four" : "four",
@@ -243,7 +243,7 @@ class RedisCacheSpec extends RedisSpec {
                 "test-list": [new Foo(name: "abc")] as List<Foo>,
                 "deleteme": null,
         ])
-        Map<String, Object> result = redisCache.get(["four", "two", "test", "missing", "test-list", "three", "deleteme"])
+        Map<String, Object> result = redisCache.getAll(["four", "two", "test", "missing", "test-list", "three", "deleteme"])
 
         then:
         result.keySet().toList() == ["four", "two", "test", "missing", "test-list", "three", "deleteme"]
@@ -257,7 +257,7 @@ class RedisCacheSpec extends RedisSpec {
         !redisCache.get("deleteme", Object).isPresent()
 
         when:
-        Map<String, Foo> typed = redisCache.get(["two", "test"], Argument.of(Foo))
+        Map<String, Foo> typed = redisCache.getAll(["two", "test"], Argument.of(Foo))
 
         then:
         typed.keySet().toList() == ["two", "test"]
@@ -265,7 +265,7 @@ class RedisCacheSpec extends RedisSpec {
         typed.get("test") == new Foo(name: "test")
 
         when:
-        redisCache.invalidate(["test", "two", "three", "four"])
+        redisCache.invalidateAllKeys(["test", "two", "three", "four"])
 
         then:
         !redisCache.get("test", Foo).isPresent()

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
@@ -228,6 +228,57 @@ class RedisCacheSpec extends RedisSpec {
         applicationContext.stop()
     }
 
+    void "test bulk read write and invalidate with redis sync cache"() {
+        setup:
+        ApplicationContext applicationContext = createApplicationContext()
+
+        when:
+        RedisCache redisCache = applicationContext.getBean(RedisCache, Qualifiers.byName("test"))
+        redisCache.put("deleteme", "should get deleted")
+        redisCache.put([
+                "three": 3,
+                "test" : new Foo(name: "test"),
+                "four" : "four",
+                "two"  : new Foo(name: "two"),
+                "test-list": [new Foo(name: "abc")] as List<Foo>,
+                "deleteme": null,
+        ])
+        Map<String, Object> result = redisCache.get(["four", "two", "test", "missing", "test-list", "three", "deleteme"])
+
+        then:
+        result.keySet().toList() == ["four", "two", "test", "missing", "test-list", "three", "deleteme"]
+        result.get("four") == "four"
+        result.get("two") == new Foo(name: "two")
+        result.get("test") == new Foo(name: "test")
+        result.get("missing") == null
+        result.get("test-list").get(0) == new Foo(name: "abc")
+        result.get("three") == 3
+        result.get("deleteme") == null
+        !redisCache.get("deleteme", Object).isPresent()
+
+        when:
+        Map<String, Foo> typed = redisCache.get(["two", "test"], Argument.of(Foo))
+
+        then:
+        typed.keySet().toList() == ["two", "test"]
+        typed.get("two") == new Foo(name: "two")
+        typed.get("test") == new Foo(name: "test")
+
+        when:
+        redisCache.invalidate(["test", "two", "three", "four"])
+
+        then:
+        !redisCache.get("test", Foo).isPresent()
+        !redisCache.get("two", Foo).isPresent()
+        !redisCache.get("three", Integer).isPresent()
+        !redisCache.get("four", String).isPresent()
+        redisCache.get("test-list", Argument.listOf(Foo)).isPresent()
+        !redisCache.get("deleteme", Object).isPresent()
+
+        cleanup:
+        applicationContext.stop()
+    }
+
     void "test invalidateAll with redis async cache that is already empty"() {
         setup:
         ApplicationContext applicationContext = createApplicationContext()

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisCacheSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.configuration.lettuce.cache
 
+import groovy.transform.Canonical
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisStringAsyncCommands
 import io.lettuce.core.protocol.AsyncCommand
@@ -248,10 +249,10 @@ class RedisCacheSpec extends RedisSpec {
         then:
         result.keySet().toList() == ["four", "two", "test", "missing", "test-list", "three", "deleteme"]
         result.get("four") == "four"
-        result.get("two") == new Foo(name: "two")
-        result.get("test") == new Foo(name: "test")
+        result.get("two").name == "two"
+        result.get("test").name == "test"
         result.get("missing") == null
-        result.get("test-list").get(0) == new Foo(name: "abc")
+        result.get("test-list").get(0).name == "abc"
         result.get("three") == 3
         result.get("deleteme") == null
         !redisCache.get("deleteme", Object).isPresent()
@@ -392,6 +393,7 @@ class RedisCacheSpec extends RedisSpec {
             applicationContext.stop()
     }
 
+    @Canonical
     static class Foo implements Serializable {
         String name
     }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
@@ -194,6 +194,57 @@ class RedisPoolCacheSpec extends RedisSpec {
         applicationContext.close()
     }
 
+    void "test bulk read write and invalidate with redis pooled sync cache"() {
+        setup:
+        ApplicationContext applicationContext = createApplicationContext()
+
+        when:
+        RedisConnectionPoolCache redisCache = applicationContext.getBean(RedisConnectionPoolCache, Qualifiers.byName("test"))
+        redisCache.put("deleteme", "should get deleted")
+        redisCache.put([
+                "three": 3,
+                "test" : new Foo(name: "test"),
+                "four" : "four",
+                "two"  : new Foo(name: "two"),
+                "test-list": [new Foo(name: "abc")] as List<Foo>,
+                "deleteme": null,
+        ])
+        Map<String, Object> result = redisCache.get(["four", "two", "test", "missing", "test-list", "three", "deleteme"])
+
+        then:
+        result.keySet().toList() == ["four", "two", "test", "missing", "test-list", "three", "deleteme"]
+        result.get("four") == "four"
+        result.get("two") == new Foo(name: "two")
+        result.get("test") == new Foo(name: "test")
+        result.get("missing") == null
+        result.get("test-list").get(0) == new Foo(name: "abc")
+        result.get("three") == 3
+        result.get("deleteme") == null
+        !redisCache.get("deleteme", Object).isPresent()
+
+        when:
+        Map<String, Foo> typed = redisCache.get(["two", "test"], Argument.of(Foo))
+
+        then:
+        typed.keySet().toList() == ["two", "test"]
+        typed.get("two") == new Foo(name: "two")
+        typed.get("test") == new Foo(name: "test")
+
+        when:
+        redisCache.invalidate(["test", "two", "three", "four"])
+
+        then:
+        !redisCache.get("test", Foo).isPresent()
+        !redisCache.get("two", Foo).isPresent()
+        !redisCache.get("three", Integer).isPresent()
+        !redisCache.get("four", String).isPresent()
+        redisCache.get("test-list", Argument.listOf(Foo)).isPresent()
+        !redisCache.get("deleteme", Object).isPresent()
+
+        cleanup:
+        applicationContext.stop()
+    }
+
     void "test creating expiration after write policy that is not of type ExpirationAfterWritePolicy"() {
         given:
         ApplicationContext applicationContext = createApplicationContext()

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
@@ -214,10 +214,10 @@ class RedisPoolCacheSpec extends RedisSpec {
         then:
         result.keySet().toList() == ["four", "two", "test", "missing", "test-list", "three", "deleteme"]
         result.get("four") == "four"
-        result.get("two") == new Foo(name: "two")
-        result.get("test") == new Foo(name: "test")
+        result.get("two").name == "two"
+        result.get("test").name == "test"
         result.get("missing") == null
-        result.get("test-list").get(0) == new Foo(name: "abc")
+        result.get("test-list").get(0).name == "abc"
         result.get("three") == 3
         result.get("deleteme") == null
         !redisCache.get("deleteme", Object).isPresent()

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/cache/RedisPoolCacheSpec.groovy
@@ -201,7 +201,7 @@ class RedisPoolCacheSpec extends RedisSpec {
         when:
         RedisConnectionPoolCache redisCache = applicationContext.getBean(RedisConnectionPoolCache, Qualifiers.byName("test"))
         redisCache.put("deleteme", "should get deleted")
-        redisCache.put([
+        redisCache.putAll([
                 "three": 3,
                 "test" : new Foo(name: "test"),
                 "four" : "four",
@@ -209,7 +209,7 @@ class RedisPoolCacheSpec extends RedisSpec {
                 "test-list": [new Foo(name: "abc")] as List<Foo>,
                 "deleteme": null,
         ])
-        Map<String, Object> result = redisCache.get(["four", "two", "test", "missing", "test-list", "three", "deleteme"])
+        Map<String, Object> result = redisCache.getAll(["four", "two", "test", "missing", "test-list", "three", "deleteme"])
 
         then:
         result.keySet().toList() == ["four", "two", "test", "missing", "test-list", "three", "deleteme"]
@@ -223,7 +223,7 @@ class RedisPoolCacheSpec extends RedisSpec {
         !redisCache.get("deleteme", Object).isPresent()
 
         when:
-        Map<String, Foo> typed = redisCache.get(["two", "test"], Argument.of(Foo))
+        Map<String, Foo> typed = redisCache.getAll(["two", "test"], Argument.of(Foo))
 
         then:
         typed.keySet().toList() == ["two", "test"]
@@ -231,7 +231,7 @@ class RedisPoolCacheSpec extends RedisSpec {
         typed.get("test") == new Foo(name: "test")
 
         when:
-        redisCache.invalidate(["test", "two", "three", "four"])
+        redisCache.invalidateAllKeys(["test", "two", "three", "four"])
 
         then:
         !redisCache.get("test", Foo).isPresent()


### PR DESCRIPTION
## Summary
- add bulk sync cache helpers for ordered multi-key get, put, and invalidate operations
- expose bulk operations on both direct and pooled Redis cache implementations
- add focused cache specs for bulk reads, writes, and invalidation

## Verification
- `gradle :micronaut-redis-lettuce:compileJava :micronaut-redis-lettuce:compileTestGroovy :micronaut-redis-lettuce:spotlessCheck`
- attempted `gradle :micronaut-redis-lettuce:test --tests "io.micronaut.configuration.lettuce.cache.RedisCacheSpec" --tests "io.micronaut.configuration.lettuce.cache.RedisPoolCacheSpec"` but Testcontainers could not start because Docker is unavailable in this environment

Resolves #220