### PR TITLE
Reuse existing Redis connection in RedisHealthIndicator

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConnectionUtil.java
@@ -85,20 +85,29 @@ public class RedisConnectionUtil {
         throw new ConfigurationException(errorMessage);
     }
 
-    private static Optional<StatefulRedisClusterConnection> findStatefulRedisClusterConnection(BeanLocator beanLocator, Optional<String> serverName) {
-        Optional<StatefulRedisClusterConnection> namedConn = serverName.flatMap(name -> beanLocator.findBean(StatefulRedisClusterConnection.class, Qualifiers.byName(name)));
+    /**
+     * Utility method to find a named bean first and fallback to the default bean.
+     *
+     * @param beanLocator Bean locator
+     * @param beanType Bean type
+     * @param serverName Server name
+     * @param <T> Bean type
+     * @return The matching bean if available
+     */
+    public static <T> Optional<T> findNamedOrDefaultBean(BeanLocator beanLocator, Class<T> beanType, Optional<String> serverName) {
+        Optional<T> namedConn = serverName.flatMap(name -> beanLocator.findBean(beanType, Qualifiers.byName(name)));
         if (namedConn.isPresent()) {
             return namedConn;
         }
-        return beanLocator.findBean(StatefulRedisClusterConnection.class);
+        return beanLocator.findBean(beanType);
+    }
+
+    private static Optional<StatefulRedisClusterConnection> findStatefulRedisClusterConnection(BeanLocator beanLocator, Optional<String> serverName) {
+        return findNamedOrDefaultBean(beanLocator, StatefulRedisClusterConnection.class, serverName);
     }
 
     private static Optional<StatefulRedisConnection> findStatefulRedisConnection(BeanLocator beanLocator, Optional<String> serverName) {
-        Optional<StatefulRedisConnection> namedConn = serverName.flatMap(name -> beanLocator.findBean(StatefulRedisConnection.class, Qualifiers.byName(name)));
-        if (namedConn.isPresent()) {
-            return namedConn;
-        }
-        return beanLocator.findBean(StatefulRedisConnection.class);
+        return findNamedOrDefaultBean(beanLocator, StatefulRedisConnection.class, serverName);
     }
 
     /**
@@ -144,19 +153,11 @@ public class RedisConnectionUtil {
     }
 
     private static Optional<RedisClusterClient> findRedisClusterClient(BeanLocator beanLocator, Optional<String> serverName) {
-        Optional<RedisClusterClient> namedClient = serverName.flatMap(name -> beanLocator.findBean(RedisClusterClient.class, Qualifiers.byName(name)));
-        if (namedClient.isPresent()) {
-            return namedClient;
-        }
-        return beanLocator.findBean(RedisClusterClient.class);
+        return findNamedOrDefaultBean(beanLocator, RedisClusterClient.class, serverName);
     }
 
     private static Optional<RedisClient> findRedisClient(BeanLocator beanLocator, Optional<String> serverName) {
-        Optional<RedisClient> namedClient = serverName.flatMap(name -> beanLocator.findBean(RedisClient.class, Qualifiers.byName(name)));
-        if (namedClient.isPresent()) {
-            return namedClient;
-        }
-        return beanLocator.findBean(RedisClient.class);
+        return findNamedOrDefaultBean(beanLocator, RedisClient.class, serverName);
     }
 
 }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -30,6 +30,7 @@ import io.micronaut.management.health.aggregator.HealthAggregator;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
@@ -44,6 +45,7 @@ import reactor.core.scheduler.Schedulers;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -93,34 +95,56 @@ public class RedisHealthIndicator implements HealthIndicator {
 
     @Override
     public Publisher<HealthResult> getResult() {
-        Flux<HealthResult> clientResults = getResult(RedisClient.class, RedisClient::connect, StatefulRedisConnection::reactive);
-        Flux<HealthResult> clusteredClientResults = getResult(RedisClusterClient.class, RedisClusterClient::connect, StatefulRedisClusterConnection::reactive);
+        Flux<HealthResult> clientResults = getResult(RedisClient.class, StatefulRedisConnection.class, RedisClient::connect, StatefulRedisConnection::reactive);
+        Flux<HealthResult> clusteredClientResults = getResult(RedisClusterClient.class, StatefulRedisClusterConnection.class, RedisClusterClient::connect, StatefulRedisClusterConnection::reactive);
         return this.healthAggregator.aggregate(
                 NAME,
                 Flux.concat(clientResults, clusteredClientResults)
         );
     }
 
-    private <T, R extends StatefulConnection<K, V>, K, V> Flux<HealthResult> getResult(Class<T> type, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {
-        Collection<BeanRegistration<T>> registrations = beanContext.getActiveBeanRegistrations(type);
+    private <T, R extends StatefulConnection<K, V>, K, V> Flux<HealthResult> getResult(Class<T> clientType, Class<R> connectionType, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {
+        Collection<BeanRegistration<T>> registrations = beanContext.getActiveBeanRegistrations(clientType);
         Flux<BeanRegistration<T>> redisClients = Flux.fromIterable(registrations);
-        return redisClients.flatMap(client -> healthResultForClient(client, getConnection, getReactive)).subscribeOn(scheduler);
+        return redisClients.flatMap(client -> healthResultForClient(client, connectionType, getConnection, getReactive)).subscribeOn(scheduler);
     }
 
-    private <T, R extends StatefulConnection<K, V>, K, V> Mono<HealthResult> healthResultForClient(BeanRegistration<T> client, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {
-        R connection;
+    private <T, R extends StatefulConnection<K, V>, K, V> Mono<HealthResult> healthResultForClient(BeanRegistration<T> client, Class<R> connectionType, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {
         String connectionName = client.getIdentifier().getName();
+        Optional<R> existingConnection = findExistingConnection(connectionType, connectionName);
         String dbName = "redis(" + connectionName + ")";
+        if (existingConnection.isPresent()) {
+            return healthResultForConnection(existingConnection.get(), dbName, getReactive, false);
+        }
+
+        R connection;
         try {
             connection = getConnection.apply(client.getBean());
         } catch (Exception e) {
             return Mono.just(healthResultForThrowable(e, dbName));
         }
+        return healthResultForConnection(connection, dbName, getReactive, true);
+    }
+
+    private <R extends StatefulConnection<K, V>, K, V> Mono<HealthResult> healthResultForConnection(R connection, String dbName, Function<R, BaseRedisReactiveCommands<K, V>> getReactive, boolean closeConnection) {
         Mono<String> pingCommand = getReactive.apply(connection).ping();
         pingCommand = pingCommand.timeout(Duration.ofSeconds(TIMEOUT_SECONDS)).retry(RETRY);
-        return pingCommand.map(s -> healthResultForPingResponse(s, dbName))
-                .onErrorResume(throwable -> Mono.just(healthResultForThrowable(throwable, dbName)))
-                .doFinally(f -> closeOnSignal(connection, f));
+        Mono<HealthResult> healthResult = pingCommand.map(s -> healthResultForPingResponse(s, dbName))
+            .onErrorResume(throwable -> Mono.just(healthResultForThrowable(throwable, dbName)));
+        if (closeConnection) {
+            return healthResult.doFinally(f -> closeOnSignal(connection, f));
+        }
+        return healthResult;
+    }
+
+    private <R> Optional<R> findExistingConnection(Class<R> connectionType, String connectionName) {
+        if (StringUtils.isNotEmpty(connectionName)) {
+            Optional<R> namedConnection = beanContext.findBean(connectionType, Qualifiers.byName(connectionName));
+            if (namedConnection.isPresent()) {
+                return namedConnection;
+            }
+        }
+        return beanContext.findBean(connectionType);
     }
 
     private <R extends StatefulConnection<K, V>, K, V> void closeOnSignal(R connection, SignalType signalType) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -71,6 +71,7 @@ public class RedisHealthIndicator implements HealthIndicator {
     private final BeanContext beanContext;
     private final Scheduler scheduler;
     private final HealthAggregator<?> healthAggregator;
+    private final RedisHealthIndicatorConfiguration configuration;
 
     // Must include the connections otherwise the health check will be unknown until the first Redis command executed
     private final RedisClient[] redisClients;
@@ -89,6 +90,7 @@ public class RedisHealthIndicator implements HealthIndicator {
         this.beanContext = beanContext;
         this.healthAggregator = healthAggregator;
         this.scheduler = Schedulers.fromExecutorService(executorService);
+        this.configuration = beanContext.findBean(RedisHealthIndicatorConfiguration.class).orElseGet(RedisHealthIndicatorConfiguration::new);
         this.redisClients = redisClients;
         this.redisClusterClients = redisClusterClients;
     }
@@ -111,10 +113,12 @@ public class RedisHealthIndicator implements HealthIndicator {
 
     private <T, R extends StatefulConnection<K, V>, K, V> Mono<HealthResult> healthResultForClient(BeanRegistration<T> client, Class<R> connectionType, Function<T, R> getConnection, Function<R, BaseRedisReactiveCommands<K, V>> getReactive) {
         String connectionName = client.getIdentifier().getName();
-        Optional<R> existingConnection = findExistingConnection(connectionType, connectionName);
         String dbName = "redis(" + connectionName + ")";
-        if (existingConnection.isPresent()) {
-            return healthResultForConnection(existingConnection.get(), dbName, getReactive, false);
+        if (configuration.isReuseConnection()) {
+            Optional<R> existingConnection = findExistingConnection(connectionType, connectionName);
+            if (existingConnection.isPresent()) {
+                return healthResultForConnection(existingConnection.get(), dbName, getReactive, false);
+            }
         }
 
         R connection;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicator.java
@@ -21,6 +21,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.micronaut.configuration.lettuce.RedisConnectionUtil;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.Requires;
@@ -30,7 +31,6 @@ import io.micronaut.management.health.aggregator.HealthAggregator;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import io.micronaut.scheduling.TaskExecutors;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
@@ -138,13 +138,11 @@ public class RedisHealthIndicator implements HealthIndicator {
     }
 
     private <R> Optional<R> findExistingConnection(Class<R> connectionType, String connectionName) {
-        if (StringUtils.isNotEmpty(connectionName)) {
-            Optional<R> namedConnection = beanContext.findBean(connectionType, Qualifiers.byName(connectionName));
-            if (namedConnection.isPresent()) {
-                return namedConnection;
-            }
-        }
-        return beanContext.findBean(connectionType);
+        return RedisConnectionUtil.findNamedOrDefaultBean(
+            beanContext,
+            connectionType,
+            Optional.ofNullable(connectionName).filter(StringUtils::isNotEmpty)
+        );
     }
 
     private <R extends StatefulConnection<K, V>, K, V> void closeOnSignal(R connection, SignalType signalType) {

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.lettuce.health;
+
+import io.micronaut.configuration.lettuce.RedisSetting;
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+/**
+ * Configuration for Redis health checks.
+ *
+ * @author graemerocher
+ * @since 7.0.0
+ */
+@ConfigurationProperties(RedisSetting.PREFIX + ".health")
+public class RedisHealthIndicatorConfiguration {
+
+    private boolean reuseConnection;
+
+    /**
+     * @return Whether the health indicator should reuse a managed connection bean when available
+     */
+    public boolean isReuseConnection() {
+        return reuseConnection;
+    }
+
+    /**
+     * @param reuseConnection True if the health indicator should reuse a managed connection bean when available
+     */
+    public void setReuseConnection(boolean reuseConnection) {
+        this.reuseConnection = reuseConnection;
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorConnectionReuseSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorConnectionReuseSpec.groovy
@@ -20,11 +20,53 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class RedisHealthIndicatorConnectionReuseSpec extends Specification {
 
-    void "health indicator reuses an existing redis connection bean"() {
+    void "health indicator opens a new redis connection by default"() {
         given:
         BeanContext beanContext = Mock()
         HealthAggregator<HealthResult> healthAggregator = Mock()
         RedisClient redisClient = Mock()
+        AtomicInteger closeCalls = new AtomicInteger()
+        StatefulRedisConnection<Object, Object> redisConnection = Mock() {
+            close() >> { closeCalls.incrementAndGet() }
+        }
+        RedisReactiveCommands<Object, Object> reactiveCommands = Mock()
+        BeanRegistration<RedisClient> registration = Stub() {
+            getBean() >> redisClient
+            getIdentifier() >> Stub(BeanIdentifier) {
+                getName() >> "default"
+            }
+        }
+        ExecutorService executorService = Executors.newSingleThreadExecutor()
+        beanContext.findBean(RedisHealthIndicatorConfiguration) >> Optional.empty()
+        RedisHealthIndicator healthIndicator = new RedisHealthIndicator(beanContext, executorService, healthAggregator, [redisClient] as RedisClient[], [] as io.lettuce.core.cluster.RedisClusterClient[])
+        beanContext.getActiveBeanRegistrations(RedisClient) >> [registration]
+        beanContext.getActiveBeanRegistrations(io.lettuce.core.cluster.RedisClusterClient) >> []
+        healthAggregator.aggregate(RedisHealthIndicator.NAME, _) >> { String name, publisher -> publisher }
+        redisClient.connect() >> redisConnection
+        redisConnection.reactive() >> reactiveCommands
+        reactiveCommands.ping() >> Mono.just("PONG")
+
+        when:
+        HealthResult result = Flux.from(healthIndicator.getResult()).blockFirst()
+
+        then:
+        result != null
+        result.status == HealthStatus.UP
+        new PollingConditions(timeout: 1).eventually {
+            assert closeCalls.get() == 1
+        }
+
+        cleanup:
+        executorService.shutdownNow()
+    }
+
+    void "health indicator reuses an existing redis connection bean when configured"() {
+        given:
+        BeanContext beanContext = Mock()
+        HealthAggregator<HealthResult> healthAggregator = Mock()
+        RedisClient redisClient = Mock()
+        RedisHealthIndicatorConfiguration configuration = new RedisHealthIndicatorConfiguration()
+        configuration.reuseConnection = true
         StatefulRedisConnection<Object, Object> redisConnection = Mock()
         RedisReactiveCommands<Object, Object> reactiveCommands = Mock()
         BeanRegistration<RedisClient> registration = Stub() {
@@ -34,12 +76,11 @@ class RedisHealthIndicatorConnectionReuseSpec extends Specification {
             }
         }
         ExecutorService executorService = Executors.newSingleThreadExecutor()
+        beanContext.findBean(RedisHealthIndicatorConfiguration) >> Optional.of(configuration)
         RedisHealthIndicator healthIndicator = new RedisHealthIndicator(beanContext, executorService, healthAggregator, [redisClient] as RedisClient[], [] as io.lettuce.core.cluster.RedisClusterClient[])
-
         beanContext.getActiveBeanRegistrations(RedisClient) >> [registration]
         beanContext.getActiveBeanRegistrations(io.lettuce.core.cluster.RedisClusterClient) >> []
         beanContext.findBean(StatefulRedisConnection, _) >> Optional.of(redisConnection)
-        beanContext.findBean(io.lettuce.core.cluster.api.StatefulRedisClusterConnection) >> Optional.empty()
         healthAggregator.aggregate(RedisHealthIndicator.NAME, _) >> { String name, publisher -> publisher }
         redisConnection.reactive() >> reactiveCommands
         reactiveCommands.ping() >> Mono.just("PONG")
@@ -57,11 +98,13 @@ class RedisHealthIndicatorConnectionReuseSpec extends Specification {
         executorService.shutdownNow()
     }
 
-    void "health indicator falls back to opening a redis connection when none exists"() {
+    void "health indicator falls back to opening a redis connection when reuse is enabled and none exists"() {
         given:
         BeanContext beanContext = Mock()
         HealthAggregator<HealthResult> healthAggregator = Mock()
         RedisClient redisClient = Mock()
+        RedisHealthIndicatorConfiguration configuration = new RedisHealthIndicatorConfiguration()
+        configuration.reuseConnection = true
         AtomicInteger closeCalls = new AtomicInteger()
         StatefulRedisConnection<Object, Object> redisConnection = Mock() {
             close() >> { closeCalls.incrementAndGet() }
@@ -74,13 +117,12 @@ class RedisHealthIndicatorConnectionReuseSpec extends Specification {
             }
         }
         ExecutorService executorService = Executors.newSingleThreadExecutor()
+        beanContext.findBean(RedisHealthIndicatorConfiguration) >> Optional.of(configuration)
         RedisHealthIndicator healthIndicator = new RedisHealthIndicator(beanContext, executorService, healthAggregator, [redisClient] as RedisClient[], [] as io.lettuce.core.cluster.RedisClusterClient[])
-
         beanContext.getActiveBeanRegistrations(RedisClient) >> [registration]
         beanContext.getActiveBeanRegistrations(io.lettuce.core.cluster.RedisClusterClient) >> []
         beanContext.findBean(StatefulRedisConnection, _) >> Optional.empty()
         beanContext.findBean(StatefulRedisConnection) >> Optional.empty()
-        beanContext.findBean(io.lettuce.core.cluster.api.StatefulRedisClusterConnection) >> Optional.empty()
         healthAggregator.aggregate(RedisHealthIndicator.NAME, _) >> { String name, publisher -> publisher }
         redisClient.connect() >> redisConnection
         redisConnection.reactive() >> reactiveCommands

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorConnectionReuseSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorConnectionReuseSpec.groovy
@@ -1,0 +1,102 @@
+package io.micronaut.configuration.lettuce.health
+
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.reactive.RedisReactiveCommands
+import io.micronaut.context.BeanContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.health.HealthStatus
+import io.micronaut.inject.BeanIdentifier
+import io.micronaut.management.health.aggregator.HealthAggregator
+import io.micronaut.management.health.indicator.HealthResult
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+class RedisHealthIndicatorConnectionReuseSpec extends Specification {
+
+    void "health indicator reuses an existing redis connection bean"() {
+        given:
+        BeanContext beanContext = Mock()
+        HealthAggregator<HealthResult> healthAggregator = Mock()
+        RedisClient redisClient = Mock()
+        StatefulRedisConnection<Object, Object> redisConnection = Mock()
+        RedisReactiveCommands<Object, Object> reactiveCommands = Mock()
+        BeanRegistration<RedisClient> registration = Stub() {
+            getBean() >> redisClient
+            getIdentifier() >> Stub(BeanIdentifier) {
+                getName() >> "default"
+            }
+        }
+        ExecutorService executorService = Executors.newSingleThreadExecutor()
+        RedisHealthIndicator healthIndicator = new RedisHealthIndicator(beanContext, executorService, healthAggregator, [redisClient] as RedisClient[], [] as io.lettuce.core.cluster.RedisClusterClient[])
+
+        beanContext.getActiveBeanRegistrations(RedisClient) >> [registration]
+        beanContext.getActiveBeanRegistrations(io.lettuce.core.cluster.RedisClusterClient) >> []
+        beanContext.findBean(StatefulRedisConnection, _) >> Optional.of(redisConnection)
+        beanContext.findBean(io.lettuce.core.cluster.api.StatefulRedisClusterConnection) >> Optional.empty()
+        healthAggregator.aggregate(RedisHealthIndicator.NAME, _) >> { String name, publisher -> publisher }
+        redisConnection.reactive() >> reactiveCommands
+        reactiveCommands.ping() >> Mono.just("PONG")
+
+        when:
+        HealthResult result = Flux.from(healthIndicator.getResult()).blockFirst()
+
+        then:
+        result != null
+        result.status == HealthStatus.UP
+        0 * redisClient.connect()
+        0 * redisConnection.close()
+
+        cleanup:
+        executorService.shutdownNow()
+    }
+
+    void "health indicator falls back to opening a redis connection when none exists"() {
+        given:
+        BeanContext beanContext = Mock()
+        HealthAggregator<HealthResult> healthAggregator = Mock()
+        RedisClient redisClient = Mock()
+        AtomicInteger closeCalls = new AtomicInteger()
+        StatefulRedisConnection<Object, Object> redisConnection = Mock() {
+            close() >> { closeCalls.incrementAndGet() }
+        }
+        RedisReactiveCommands<Object, Object> reactiveCommands = Mock()
+        BeanRegistration<RedisClient> registration = Stub() {
+            getBean() >> redisClient
+            getIdentifier() >> Stub(BeanIdentifier) {
+                getName() >> "default"
+            }
+        }
+        ExecutorService executorService = Executors.newSingleThreadExecutor()
+        RedisHealthIndicator healthIndicator = new RedisHealthIndicator(beanContext, executorService, healthAggregator, [redisClient] as RedisClient[], [] as io.lettuce.core.cluster.RedisClusterClient[])
+
+        beanContext.getActiveBeanRegistrations(RedisClient) >> [registration]
+        beanContext.getActiveBeanRegistrations(io.lettuce.core.cluster.RedisClusterClient) >> []
+        beanContext.findBean(StatefulRedisConnection, _) >> Optional.empty()
+        beanContext.findBean(StatefulRedisConnection) >> Optional.empty()
+        beanContext.findBean(io.lettuce.core.cluster.api.StatefulRedisClusterConnection) >> Optional.empty()
+        healthAggregator.aggregate(RedisHealthIndicator.NAME, _) >> { String name, publisher -> publisher }
+        redisClient.connect() >> redisConnection
+        redisConnection.reactive() >> reactiveCommands
+        reactiveCommands.ping() >> Mono.just("PONG")
+
+        when:
+        HealthResult result = Flux.from(healthIndicator.getResult()).blockFirst()
+
+        then:
+        result != null
+        result.status == HealthStatus.UP
+        new PollingConditions(timeout: 1).eventually {
+            assert closeCalls.get() == 1
+        }
+
+        cleanup:
+        executorService.shutdownNow()
+    }
+}

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorSpec.groovy
@@ -1,13 +1,30 @@
 package io.micronaut.configuration.lettuce.health
 
 import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisURI
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.codec.StringCodec
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
+import io.lettuce.core.resource.ClientResources
+import io.micronaut.configuration.lettuce.AbstractRedisConfiguration
+import io.micronaut.configuration.lettuce.ClientResourcesMutator
+import io.micronaut.configuration.lettuce.DefaultRedisClientFactory
 import io.micronaut.configuration.lettuce.RedisSpec
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
 import io.micronaut.health.HealthStatus
 import io.micronaut.management.health.indicator.HealthResult
 import io.micronaut.redis.test.RedisContainerUtils
+import jakarta.inject.Singleton
+import org.jspecify.annotations.Nullable
 import reactor.core.publisher.Flux
-import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * @author graemerocher
@@ -15,7 +32,37 @@ import spock.lang.Specification
  */
 class RedisHealthIndicatorSpec extends RedisSpec {
 
-    private static String MAX_HEAP_SETTING = "maxmemory 256M"
+    void "redis health indicator reuses existing redis connection for repeated checks"() {
+        when:
+        ApplicationContext applicationContext = ApplicationContext.run([
+                'redis.port': RedisContainerUtils.getRedisPort(),
+                'spec.name': CountingRedisClientFactory.SPEC_NAME
+        ])
+        RedisHealthIndicator healthIndicator = applicationContext.getBean(RedisHealthIndicator)
+        ConnectCounter connectCounter = applicationContext.getBean(ConnectCounter)
+
+        then:
+        connectCounter.connectCalls == 0
+
+        when:
+        HealthResult first = Flux.from(healthIndicator.getResult()).blockFirst()
+        int initialConnectCalls = connectCounter.connectCalls
+        HealthResult second = Flux.from(healthIndicator.getResult()).blockFirst()
+        HealthResult third = Flux.from(healthIndicator.getResult()).blockFirst()
+
+        then:
+        first != null
+        first.status == HealthStatus.UP
+        second != null
+        second.status == HealthStatus.UP
+        third != null
+        third.status == HealthStatus.UP
+        initialConnectCalls == 1
+        connectCounter.connectCalls == initialConnectCalls
+
+        cleanup:
+        applicationContext.close()
+    }
 
     void "test redis health indicator"() {
         when:
@@ -64,5 +111,96 @@ class RedisHealthIndicatorSpec extends RedisSpec {
 
         cleanup:
         applicationContext.close()
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class CountingRedisClientFactory {
+        static final String SPEC_NAME = "redis-health-indicator-connection-reuse"
+
+        @Singleton
+        ConnectCounter connectCounter() {
+            return new ConnectCounter()
+        }
+
+        @Singleton
+        @Primary
+        @Replaces(RedisClient)
+        RedisClient redisClient(
+                @Primary AbstractRedisConfiguration config,
+                @Nullable @Primary ClientResources defaultClientResources,
+                @Nullable List<ClientResourcesMutator> mutators,
+                ConnectCounter connectCounter
+        ) {
+            RedisClient delegate = new DefaultRedisClientFactory<String, String>(StringCodec.ASCII)
+                    .redisClient(config, defaultClientResources, mutators)
+            return new CountingRedisClient(delegate, connectCounter)
+        }
+    }
+
+    static final class ConnectCounter {
+        private final AtomicInteger connectCalls = new AtomicInteger()
+
+        int getConnectCalls() {
+            return connectCalls.get()
+        }
+
+        void incrementConnectCalls() {
+            connectCalls.incrementAndGet()
+        }
+    }
+
+    static final class CountingRedisClient extends RedisClient {
+        private final RedisClient delegate
+        private final ConnectCounter connectCounter
+
+        CountingRedisClient(RedisClient delegate, ConnectCounter connectCounter) {
+            this.delegate = delegate
+            this.connectCounter = connectCounter
+        }
+
+        @Override
+        StatefulRedisConnection<String, String> connect() {
+            connectCounter.incrementConnectCalls()
+            return delegate.connect()
+        }
+
+        @Override
+        <K, V> StatefulRedisConnection<K, V> connect(RedisCodec<K, V> codec) {
+            connectCounter.incrementConnectCalls()
+            return delegate.connect(codec)
+        }
+
+        @Override
+        StatefulRedisConnection<String, String> connect(RedisURI redisURI) {
+            connectCounter.incrementConnectCalls()
+            return delegate.connect(redisURI)
+        }
+
+        @Override
+        <K, V> StatefulRedisConnection<K, V> connect(RedisCodec<K, V> codec, RedisURI redisURI) {
+            connectCounter.incrementConnectCalls()
+            return delegate.connect(codec, redisURI)
+        }
+
+        @Override
+        StatefulRedisPubSubConnection<String, String> connectPubSub() {
+            return delegate.connectPubSub()
+        }
+
+        @Override
+        <K, V> StatefulRedisPubSubConnection<K, V> connectPubSub(RedisCodec<K, V> codec) {
+            return delegate.connectPubSub(codec)
+        }
+
+        @Override
+        void shutdown() {
+            delegate.shutdown()
+        }
+
+        @Override
+        void shutdown(long quietPeriod, long timeout, TimeUnit timeUnit) {
+            delegate.shutdown(quietPeriod, timeout, timeUnit)
+        }
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/health/RedisHealthIndicatorSpec.groovy
@@ -32,10 +32,43 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 class RedisHealthIndicatorSpec extends RedisSpec {
 
-    void "redis health indicator reuses existing redis connection for repeated checks"() {
+    void "redis health indicator opens a new redis connection for repeated checks by default"() {
         when:
         ApplicationContext applicationContext = ApplicationContext.run([
                 'redis.port': RedisContainerUtils.getRedisPort(),
+                'spec.name': CountingRedisClientFactory.SPEC_NAME
+        ])
+        RedisHealthIndicator healthIndicator = applicationContext.getBean(RedisHealthIndicator)
+        ConnectCounter connectCounter = applicationContext.getBean(ConnectCounter)
+
+        then:
+        connectCounter.connectCalls == 0
+
+        when:
+        HealthResult first = Flux.from(healthIndicator.getResult()).blockFirst()
+        int initialConnectCalls = connectCounter.connectCalls
+        HealthResult second = Flux.from(healthIndicator.getResult()).blockFirst()
+        HealthResult third = Flux.from(healthIndicator.getResult()).blockFirst()
+
+        then:
+        first != null
+        first.status == HealthStatus.UP
+        initialConnectCalls == 1
+        second != null
+        second.status == HealthStatus.UP
+        third != null
+        third.status == HealthStatus.UP
+        connectCounter.connectCalls == 3
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "redis health indicator can reuse existing redis connection for repeated checks"() {
+        when:
+        ApplicationContext applicationContext = ApplicationContext.run([
+                'redis.port': RedisContainerUtils.getRedisPort(),
+                'redis.health.reuse-connection': true,
                 'spec.name': CountingRedisClientFactory.SPEC_NAME
         ])
         RedisHealthIndicator healthIndicator = applicationContext.getBean(RedisHealthIndicator)

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -88,6 +88,15 @@ redis:
     enabled: false
 ----
 
+By default, each health check opens a fresh Redis connection so the probe verifies new connections can still be established. If you prefer to reuse an existing managed Lettuce connection bean when available, enable `redis.health.reuse-connection`:
+
+[configuration]
+----
+redis:
+   health:
+      reuse-connection: true
+----
+
 See the section on the https://docs.micronaut.io/latest/guide/index.html#healthEndpoint[Health Endpoint] for more information.
 
 == Disabling Redis


### PR DESCRIPTION
## Summary
- reuse existing managed Lettuce connection beans during health checks
- only open and close a new connection when no managed connection bean exists
- add coverage for connection reuse and fallback behavior

## Tests
- ./gradlew :micronaut-redis-lettuce:test --tests 'io.micronaut.configuration.lettuce.health.RedisHealthIndicatorConnectionReuseSpec'

Resolves #651
