### PR TITLE
Support redis.password alongside redis.uri

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/AbstractRedisConfiguration.java
@@ -107,6 +107,16 @@ public abstract class AbstractRedisConfiguration extends RedisURI implements Nam
     }
 
     /**
+     * Sets the Redis password as an alias for {@link #setAuthentication(CharSequence)}.
+     *
+     * @param password The Redis password
+     * @since 7.0.0
+     */
+    public void setPassword(@Nullable String password) {
+        setAuthentication(password);
+    }
+
+    /**
      * Returns the pool size (number of threads) for IO threads. The indicated size does not reflect the number for all IO
      * threads. TCP and socket connections (epoll) require different IO pool.
      *

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -94,6 +94,26 @@ class RedisConfigurationSpec extends Specification {
         client.shutdown()
     }
 
+    void "test uri password configuration is applied when bound from properties"() {
+        given:
+        applicationContext = ApplicationContext.run([
+                'redis.uri'     : 'redis://localhost:6379',
+                'redis.password': 's3cret'
+        ])
+
+        when:
+        DefaultRedisConfiguration configuration = applicationContext.getBean(DefaultRedisConfiguration)
+        RedisClient client = applicationContext.getBean(RedisClient)
+
+        then:
+        passwordOf(configuration) == 's3cret'
+        passwordOf(configuration.getUri().orElseThrow()) == 's3cret'
+        passwordOf(client.@redisURI) == 's3cret'
+
+        cleanup:
+        client.shutdown()
+    }
+
     void "test uri configuration applies separately bound RedisURI settings"() {
         given:
         DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
@@ -162,6 +182,26 @@ class RedisConfigurationSpec extends Specification {
         replicaUris*.ssl == [true]
         replicaUris*.startTls == [true]
         replicaUris*.verifyMode == [SslVerifyMode.CA]
+    }
+
+    void "test named uri password configuration is applied when bound from properties"() {
+        given:
+        applicationContext = ApplicationContext.run([
+                'redis.servers.reports.uri'     : 'redis://localhost:6379',
+                'redis.servers.reports.password': 'named-secret'
+        ])
+
+        when:
+        NamedRedisServersConfiguration configuration = applicationContext.getBean(NamedRedisServersConfiguration, Qualifiers.byName("reports"))
+        RedisClient client = applicationContext.getBean(RedisClient, Qualifiers.byName("reports"))
+
+        then:
+        passwordOf(configuration) == 'named-secret'
+        passwordOf(configuration.getUri().orElseThrow()) == 'named-secret'
+        passwordOf(client.@redisURI) == 'named-secret'
+
+        cleanup:
+        client.shutdown()
     }
 
     private static String passwordOf(AbstractRedisConfiguration configuration) {

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -11,7 +11,7 @@ redis:
     timeout: 30s
 ----
 
-When `redis.uri` is present, you can still provide password authentication separately with `redis.authentication`, or embed credentials directly in the URI. Use `redis.authentication` instead of a non-existent `redis.password` property.
+When `redis.uri` is present, you can still provide password authentication separately with either `redis.authentication` or `redis.password`, or embed credentials directly in the URI.
 
 === Configuring Lettuce Command Latency Metrics
 

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -11,6 +11,8 @@ redis:
     timeout: 30s
 ----
 
+When `redis.uri` is present, you can still provide password authentication separately with `redis.authentication`, or embed credentials directly in the URI. Use `redis.authentication` instead of a non-existent `redis.password` property.
+
 === Configuring Lettuce Command Latency Metrics
 
 If Micrometer is on the classpath, the Lettuce command latency recorder is enabled automatically. Histogram metrics remain enabled by default for compatibility, but you can now customize them in configuration:

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -27,6 +27,8 @@ redis:
 
 TIP: The `redis.uri` setting should be in the format as described in the https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details[Connection URIs] section of the Lettuce wiki
 
+IMPORTANT: If Redis requires authentication, you can either include credentials directly in `redis.uri`, for example `redis://:secret@localhost` or `redis://username:secret@localhost`, or provide a password separately with `redis.authentication` alongside `redis.uri`. There is no separate `redis.password` property.
+
 You can also specify multiple Redis URIs using `redis.uris` in which case a `RedisClusterClient` is created instead.
 
 === Configuring Lettuce ClientResources and threads

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -27,7 +27,7 @@ redis:
 
 TIP: The `redis.uri` setting should be in the format as described in the https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details[Connection URIs] section of the Lettuce wiki
 
-IMPORTANT: If Redis requires authentication, you can either include credentials directly in `redis.uri`, for example `redis://:secret@localhost` or `redis://username:secret@localhost`, or provide a password separately with `redis.authentication` alongside `redis.uri`. There is no separate `redis.password` property.
+IMPORTANT: If Redis requires authentication, you can either include credentials directly in `redis.uri`, for example `redis://:secret@localhost` or `redis://username:secret@localhost`, or provide a password separately with either `redis.authentication` or `redis.password` alongside `redis.uri`.
 
 You can also specify multiple Redis URIs using `redis.uris` in which case a `RedisClusterClient` is created instead.
 


### PR DESCRIPTION
## Summary
- add a compatibility alias so `redis.password` binds the same way as `redis.authentication`
- preserve password propagation into merged `RedisURI` values when `redis.uri` is configured
- update the guide to document URI auth, `redis.authentication`, and `redis.password`

## Verification
- `./gradlew :micronaut-redis-lettuce:test --tests io.micronaut.configuration.lettuce.RedisConfigurationSpec`
- `./gradlew spotlessCheck`

Resolves #85
