### PR TITLE
Propagate redis authentication into configured URIs

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.lettuce;
 
+import io.lettuce.core.RedisCredentialsProvider;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.SslVerifyMode;
 
@@ -83,6 +84,36 @@ abstract class RedisConfigurationWithUriSettings extends AbstractRedisConfigurat
         configuredRedisUriSettings.updateAndGet(settings -> settings.withVerifyMode(verifyMode));
     }
 
+    @Override
+    public void setAuthentication(CharSequence password) {
+        super.setAuthentication(password);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+    }
+
+    @Override
+    public void setAuthentication(char[] password) {
+        super.setAuthentication(password);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+    }
+
+    @Override
+    public void setAuthentication(String username, char[] password) {
+        super.setAuthentication(username, password);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+    }
+
+    @Override
+    public void setAuthentication(String username, CharSequence password) {
+        super.setAuthentication(username, password);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+    }
+
+    @Override
+    public void setCredentialsProvider(RedisCredentialsProvider credentialsProvider) {
+        super.setCredentialsProvider(credentialsProvider);
+        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(credentialsProvider));
+    }
+
     private RedisURI applyConfiguredRedisUriSettings(RedisURI redisURI) {
         return configuredRedisUriSettings.get().apply(redisURI, getClientName());
     }
@@ -92,32 +123,40 @@ abstract class RedisConfigurationWithUriSettings extends AbstractRedisConfigurat
         Integer database,
         Boolean ssl,
         Boolean startTls,
-        SslVerifyMode verifyMode
+        SslVerifyMode verifyMode,
+        RedisCredentialsProvider credentialsProvider
     ) {
-        private static final ConfiguredRedisUriSettings EMPTY = new ConfiguredRedisUriSettings(null, null, null, null, null);
+        private static final ConfiguredRedisUriSettings EMPTY = new ConfiguredRedisUriSettings(null, null, null, null, null, null);
 
         private ConfiguredRedisUriSettings withTimeout(Duration newTimeout) {
-            return new ConfiguredRedisUriSettings(newTimeout, database, ssl, startTls, verifyMode);
+            return new ConfiguredRedisUriSettings(newTimeout, database, ssl, startTls, verifyMode, credentialsProvider);
         }
 
         private ConfiguredRedisUriSettings withDatabase(Integer newDatabase) {
-            return new ConfiguredRedisUriSettings(timeout, newDatabase, ssl, startTls, verifyMode);
+            return new ConfiguredRedisUriSettings(timeout, newDatabase, ssl, startTls, verifyMode, credentialsProvider);
         }
 
         private ConfiguredRedisUriSettings withSsl(Boolean newSsl) {
-            return new ConfiguredRedisUriSettings(timeout, database, newSsl, startTls, verifyMode);
+            return new ConfiguredRedisUriSettings(timeout, database, newSsl, startTls, verifyMode, credentialsProvider);
         }
 
         private ConfiguredRedisUriSettings withStartTls(Boolean newStartTls) {
-            return new ConfiguredRedisUriSettings(timeout, database, ssl, newStartTls, verifyMode);
+            return new ConfiguredRedisUriSettings(timeout, database, ssl, newStartTls, verifyMode, credentialsProvider);
         }
 
         private ConfiguredRedisUriSettings withVerifyMode(SslVerifyMode newVerifyMode) {
-            return new ConfiguredRedisUriSettings(timeout, database, ssl, startTls, newVerifyMode);
+            return new ConfiguredRedisUriSettings(timeout, database, ssl, startTls, newVerifyMode, credentialsProvider);
+        }
+
+        private ConfiguredRedisUriSettings withCredentialsProvider(RedisCredentialsProvider newCredentialsProvider) {
+            return new ConfiguredRedisUriSettings(timeout, database, ssl, startTls, verifyMode, newCredentialsProvider);
         }
 
         private RedisURI apply(RedisURI redisURI, String clientName) {
             RedisURI.Builder builder = RedisURI.builder(redisURI);
+            if (credentialsProvider != null) {
+                builder.withAuthentication(credentialsProvider);
+            }
             if (timeout != null) {
                 builder.withTimeout(timeout);
             }

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/RedisConfigurationWithUriSettings.java
@@ -87,30 +87,34 @@ abstract class RedisConfigurationWithUriSettings extends AbstractRedisConfigurat
     @Override
     public void setAuthentication(CharSequence password) {
         super.setAuthentication(password);
-        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+        updateConfiguredCredentialsProvider(getCredentialsProvider());
     }
 
     @Override
     public void setAuthentication(char[] password) {
         super.setAuthentication(password);
-        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+        updateConfiguredCredentialsProvider(getCredentialsProvider());
     }
 
     @Override
     public void setAuthentication(String username, char[] password) {
         super.setAuthentication(username, password);
-        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+        updateConfiguredCredentialsProvider(getCredentialsProvider());
     }
 
     @Override
     public void setAuthentication(String username, CharSequence password) {
         super.setAuthentication(username, password);
-        configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(getCredentialsProvider()));
+        updateConfiguredCredentialsProvider(getCredentialsProvider());
     }
 
     @Override
     public void setCredentialsProvider(RedisCredentialsProvider credentialsProvider) {
         super.setCredentialsProvider(credentialsProvider);
+        updateConfiguredCredentialsProvider(credentialsProvider);
+    }
+
+    private void updateConfiguredCredentialsProvider(RedisCredentialsProvider credentialsProvider) {
         configuredRedisUriSettings.updateAndGet(settings -> settings.withCredentialsProvider(credentialsProvider));
     }
 

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -170,7 +170,10 @@ class RedisConfigurationSpec extends Specification {
 
     private static String passwordOf(RedisURI redisURI) {
         RedisCredentialsProvider credentialsProvider = redisURI.getCredentialsProvider()
-        def credentials = credentialsProvider.resolveCredentials().block()
+        if (credentialsProvider == null) {
+            return null
+        }
+        def credentials = credentialsProvider.resolveCredentials().block(Duration.ofSeconds(5))
         return credentials?.hasPassword() ? new String(credentials.password) : null
     }
 }

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.configuration.lettuce
 
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisCredentialsProvider
 import io.lettuce.core.RedisURI
 import io.lettuce.core.SslVerifyMode
 import io.lettuce.core.codec.StringCodec
@@ -73,10 +74,31 @@ class RedisConfigurationSpec extends Specification {
         namedConfig.isHistogram()
     }
 
+    void "test uri authentication configuration is applied when bound from properties"() {
+        given:
+        applicationContext = ApplicationContext.run([
+                'redis.uri'           : 'redis://localhost:6379',
+                'redis.authentication': 's3cret'
+        ])
+
+        when:
+        DefaultRedisConfiguration configuration = applicationContext.getBean(DefaultRedisConfiguration)
+        RedisClient client = applicationContext.getBean(RedisClient)
+
+        then:
+        passwordOf(configuration) == 's3cret'
+        passwordOf(configuration.getUri().orElseThrow()) == 's3cret'
+        passwordOf(client.@redisURI) == 's3cret'
+
+        cleanup:
+        client.shutdown()
+    }
+
     void "test uri configuration applies separately bound RedisURI settings"() {
         given:
         DefaultRedisConfiguration configuration = new DefaultRedisConfiguration()
         configuration.setUri(URI.create("redis://localhost:6379"))
+        configuration.setAuthentication("s3cret")
         configuration.setTimeout(Duration.ofSeconds(1))
         configuration.setDatabase(4)
         configuration.setClientName("default-client")
@@ -89,12 +111,14 @@ class RedisConfigurationSpec extends Specification {
         RedisClient client = new DefaultRedisClientFactory<String, String>(StringCodec.UTF8).redisClient(configuration)
 
         then:
+        passwordOf(mergedUri) == 's3cret'
         mergedUri.timeout == Duration.ofSeconds(1)
         mergedUri.database == 4
         mergedUri.clientName == "default-client"
         mergedUri.ssl
         mergedUri.startTls
         !mergedUri.verifyPeer
+        passwordOf(client.@redisURI) == 's3cret'
         client.@redisURI.timeout == Duration.ofSeconds(1)
         client.@redisURI.database == 4
         client.@redisURI.clientName == "default-client"
@@ -114,6 +138,7 @@ class RedisConfigurationSpec extends Specification {
         configuration.setTimeout(Duration.ofSeconds(5))
         configuration.setDatabase(7)
         configuration.setClientName("named-client")
+        configuration.setAuthentication("named-secret")
         configuration.setSsl(true)
         configuration.setStartTls(true)
         configuration.setVerifyPeer(SslVerifyMode.CA)
@@ -123,17 +148,29 @@ class RedisConfigurationSpec extends Specification {
         List<RedisURI> replicaUris = configuration.getReplicaUris()
 
         then:
+        clusterUris.collect(this::passwordOf) == ['named-secret', 'named-secret']
         clusterUris*.timeout == [Duration.ofSeconds(5), Duration.ofSeconds(5)]
         clusterUris*.database == [7, 7]
         clusterUris*.clientName == ["named-client", "named-client"]
         clusterUris*.ssl == [true, true]
         clusterUris*.startTls == [true, true]
         clusterUris*.verifyMode == [SslVerifyMode.CA, SslVerifyMode.CA]
+        replicaUris.collect(this::passwordOf) == ['named-secret']
         replicaUris*.timeout == [Duration.ofSeconds(5)]
         replicaUris*.database == [7]
         replicaUris*.clientName == ["named-client"]
         replicaUris*.ssl == [true]
         replicaUris*.startTls == [true]
         replicaUris*.verifyMode == [SslVerifyMode.CA]
+    }
+
+    private static String passwordOf(AbstractRedisConfiguration configuration) {
+        return passwordOf((RedisURI) configuration)
+    }
+
+    private static String passwordOf(RedisURI redisURI) {
+        RedisCredentialsProvider credentialsProvider = redisURI.getCredentialsProvider()
+        def credentials = credentialsProvider.resolveCredentials().block()
+        return credentials?.hasPassword() ? new String(credentials.password) : null
     }
 }


### PR DESCRIPTION
## Summary
- propagate separately bound Redis authentication into merged `RedisURI` instances when `redis.uri` is configured
- preserve authentication for direct, named, and property-bound configuration paths
- add regression coverage for property-bound auth and named URI collections

## Verification
- `./gradlew :micronaut-redis-lettuce:test --tests 'io.micronaut.configuration.lettuce.RedisConfigurationSpec'`
- `./gradlew spotlessCheck`

Resolves #304
