### PR TITLE
Fix cache bean instantiation when Redis is disabled

### DIFF
--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisCache.java
@@ -50,6 +50,7 @@ import java.util.function.Supplier;
  * @since 1.0
  */
 @EachBean(RedisCacheConfiguration.class)
+@Requires(property = RedisSetting.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 @Requires(classes = SyncCache.class, property = RedisSetting.REDIS_POOL + ".enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.TRUE)
 public class RedisCache extends AbstractRedisCache<StatefulConnection<byte[], byte[]>> {
     private final RedisAsyncCache asyncCache;

--- a/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
+++ b/redis-lettuce/src/main/java/io/micronaut/configuration/lettuce/cache/RedisConnectionPoolCache.java
@@ -53,6 +53,7 @@ import java.util.function.Supplier;
  * @since 5.3.0
  */
 @EachBean(RedisCacheConfiguration.class)
+@Requires(property = RedisSetting.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 @Requires(classes = SyncCache.class, property = RedisSetting.REDIS_POOL + ".enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.FALSE)
 public class RedisConnectionPoolCache extends AbstractRedisCache<AsyncPool<StatefulConnection<byte[], byte[]>>> {
     private static final Logger LOG = LoggerFactory.getLogger(RedisConnectionPoolCache.class);

--- a/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
+++ b/redis-lettuce/src/test/groovy/io/micronaut/configuration/lettuce/RedisConfigurationSpec.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.configuration.lettuce
 
+import io.micronaut.cache.DefaultCacheManager
+import io.micronaut.cache.SyncCache
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisCredentialsProvider
@@ -51,6 +53,43 @@ class RedisConfigurationSpec extends Specification {
 
         then:
         thrown(NoSuchBeanException)
+    }
+
+    void "test DefaultCacheManager available when redis disabled and caches configured"() {
+        given:
+        applicationContext = ApplicationContext.run([
+                'redis.enabled'                     : false,
+                'redis.host'                        : 'localhost',
+                'redis.port'                        : 6379,
+                'redis.caches.test.enabled'         : true,
+                'redis.caches.test.expire-after-write': '24h'
+        ])
+
+        when:
+        DefaultCacheManager cacheManager = applicationContext.getBean(DefaultCacheManager)
+
+        then:
+        cacheManager != null
+        applicationContext.getBeansOfType(SyncCache).isEmpty()
+    }
+
+    void "test DefaultCacheManager available when redis disabled and pooled caches configured"() {
+        given:
+        applicationContext = ApplicationContext.run([
+                'redis.enabled'                     : false,
+                'redis.host'                        : 'localhost',
+                'redis.port'                        : 6379,
+                'redis.pool.enabled'                : true,
+                'redis.caches.test.enabled'         : true,
+                'redis.caches.test.expire-after-write': '24h'
+        ])
+
+        when:
+        DefaultCacheManager cacheManager = applicationContext.getBean(DefaultCacheManager)
+
+        then:
+        cacheManager != null
+        applicationContext.getBeansOfType(SyncCache).isEmpty()
     }
 
     void "test redis metrics configuration binds command latency recorder settings"() {


### PR DESCRIPTION
## Summary
- guard Redis cache beans behind `redis.enabled` for both pooled and non-pooled cache implementations
- prevent `DefaultCacheManager` from failing when Redis cache configuration is present but Redis is explicitly disabled
- add regression coverage for both cache modes in `RedisConfigurationSpec`

## Verification
- `./gradlew :micronaut-redis-lettuce:test --tests 'io.micronaut.configuration.lettuce.RedisConfigurationSpec'`
- `./gradlew spotlessCheck`

Resolves #763
